### PR TITLE
Updated to v0.9.3

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,6 @@ AUTH_LIFE="86400"
 #The idle time before being logged out
 IDLE_TIME="28800"
 # Version of the app
-APP_VERSION="0.9.0"
+APP_VERSION="0.9.2"
 # Whether to set cookies as secure (requires HTTPS)
 COOKIE_SECURE="false"

--- a/.env
+++ b/.env
@@ -7,3 +7,5 @@ AUTH_LIFE="86400"
 IDLE_TIME="28800"
 # Version of the app
 APP_VERSION="0.9.0"
+# Whether to set cookies as secure (requires HTTPS)
+COOKIE_SECURE="false"

--- a/.env
+++ b/.env
@@ -6,6 +6,6 @@ AUTH_LIFE="86400"
 #The idle time before being logged out
 IDLE_TIME="28800"
 # Version of the app
-APP_VERSION="0.9.2"
+APP_VERSION="0.9.3"
 # Whether to set cookies as secure (requires HTTPS)
 COOKIE_SECURE="false"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Sprout Track Changelog
 
-## v0.9.2 (Release) - April 2025
+## v0.9.3 (Release) - April 2025
 
 ### Changes
 
 - Fixed an issue where etc/timezones isn't available in docker images
 - Added the ability to set cookie auth to require HTTPS or not.  This is added to the .env file.  When enabled the cookie will only be valid and sent when the app is accessed over HTTPS.  When set to false the cookie will be valid and sent over HTTP or HTTPS.  IMPORTANT: When setting this to true you must have an SSL certificate in place otherwise all main API's will be blocked.
+- Added the ability to disable Next.js telemetry collection in the setup scripts
 
 ## v0.9.0 (Beta Release) - April 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Sprout Track Changelog
 
-## v0.9.3 (Release) - April 2025
+## v0.9.3 (Beta Patch) - April 2025
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Sprout Track Changelog
 
+## v0.9.2 (Release) - April 2025
+
+### Changes
+
+- Fixed an issue where etc/timezones isn't available in docker images
+- Added the ability to set cookie auth to require HTTPS or not.  This is added to the .env file.  When enabled the cookie will only be valid and sent when the app is accessed over HTTPS.  When set to false the cookie will be valid and sent over HTTP or HTTPS.  IMPORTANT: When setting this to true you must have an SSL certificate in place otherwise all main API's will be blocked.
+
 ## v0.9.0 (Beta Release) - April 2025
 
 The beta release of Sprout Track as a self-hostable baby tracking application.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use Node.js LTS as the base image
 FROM node:22-alpine
 
+# Install tzdata package for timezone support
+RUN apk add --no-cache tzdata
+
 # Set working directory
 WORKDIR /app
 
@@ -24,6 +27,7 @@ RUN npm run build
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV TZ=UTC
 
 # Update database URL to point to the volume
 ENV DATABASE_URL="file:/db/baby-tracker.db"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ COPY prisma ./prisma/
 # Install dependencies
 RUN npm ci
 
+# Disable Next.js telemetry
+RUN npm exec next telemetry disable
+
 # Note: Prisma client generation moved to docker-startup.sh
 
 # Copy application files

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A Next.js application for tracking baby activities, milestones, and development.
   - [Database Scripts](#database-scripts)
   - [Utility Scripts](#utility-scripts)
   - [Updating the Application](#updating-the-application)
+- [Environment Variables](#environment-variables)
 - [Docker Deployment](#docker-deployment)
   - [Prerequisites](#prerequisites-1)
   - [Quick Docker Setup](#quick-docker-setup)
@@ -235,6 +236,29 @@ This will:
 5. Manage service stop/start as needed
 
 Each script can also be run independently for specific operations.
+
+## Environment Variables
+
+The application can be configured using environment variables in the `.env` file. Here are the available options:
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `DATABASE_URL` | Path to the SQLite database | `"file:../db/baby-tracker.db"` | `"file:/path/to/custom/db.sqlite"` |
+| `SERVICE_NAME` | Name of the systemd service | `"baby-tracker"` | `"sprout-track"` |
+| `AUTH_LIFE` | Authentication token validity period in seconds | `"86400"` (24 hours) | `"43200"` (12 hours) |
+| `IDLE_TIME` | Idle timeout before automatic logout in seconds | `"28800"` (8 hours) | `"3600"` (1 hour) |
+| `APP_VERSION` | Application version | `"0.9.0"` | `"1.0.0"` |
+| `COOKIE_SECURE` | Whether cookies require HTTPS connections | `"false"` | `"true"` |
+
+### Important Notes:
+
+- **DATABASE_URL**: Changing this after initial setup requires migrating your data manually.
+- **AUTH_LIFE**: Lower values increase security but require more frequent logins.
+- **IDLE_TIME**: Determines how long a user can be inactive before being logged out.
+- **COOKIE_SECURE**: 
+  - Set to `"false"` to allow cookies on non-HTTPS connections (development or initial setup)
+  - Set to `"true"` when you have an SSL certificate in place (recommended for production)
+  - When set to `"true"`, the application will only work over HTTPS connections
 
 ## Docker Deployment
 

--- a/Scripts/setup.sh
+++ b/Scripts/setup.sh
@@ -45,6 +45,11 @@ if [ $? -ne 0 ]; then
 fi
 echo "Dependencies installed successfully."
 
+# Disable Next.js telemetry
+echo "Disabling Next.js telemetry..."
+npm exec next telemetry disable
+echo "Next.js telemetry disabled."
+
 # Step 3: Generate Prisma client
 echo "Step 3: Generating Prisma client..."
 npm run prisma:generate

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: NextRequest) {
     // Clear the caretakerId cookie with the same settings it was set with
     response.cookies.set('caretakerId', '', {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: process.env.COOKIE_SECURE === 'true',
       sameSite: 'strict',
       path: '/',
       maxAge: 0, // Expire immediately

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -89,7 +89,7 @@ export async function POST(req: NextRequest) {
         // Also set the caretakerId cookie for backward compatibility
         response.cookies.set('caretakerId', 'system', {
           httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
+          secure: process.env.COOKIE_SECURE === 'true',
           sameSite: 'strict',
           maxAge: TOKEN_EXPIRATION, // Use AUTH_LIFE env variable
           path: '/',
@@ -148,7 +148,7 @@ export async function POST(req: NextRequest) {
         // Also set the caretakerId cookie for backward compatibility
         response.cookies.set('caretakerId', caretaker.id, {
           httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
+          secure: process.env.COOKIE_SECURE === 'true',
           sameSite: 'strict',
           maxAge: TOKEN_EXPIRATION, // Use AUTH_LIFE env variable
           path: '/',

--- a/app/api/authReadme.md
+++ b/app/api/authReadme.md
@@ -158,9 +158,12 @@ Authentication errors return appropriate HTTP status codes:
 
 1. **Cookie Security**:
    - HTTP-only: Prevents JavaScript access to the cookie
-   - Secure: Only sent over HTTPS in production
+   - Secure: Only sent over HTTPS when `COOKIE_SECURE` environment variable is set to `"true"`
    - SameSite: Strict to prevent CSRF attacks
    - Limited expiration: 30 minutes
+   - The `COOKIE_SECURE` environment variable (in `.env` file) controls whether cookies require HTTPS:
+     - Set to `"false"` (default) to allow cookies on non-HTTPS connections
+     - Set to `"true"` when you have an SSL certificate in place and want to enforce secure cookies
 
 2. **Session Management**:
    - Two separate timeout mechanisms are implemented:

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -7,6 +7,16 @@ mkdir -p /db
 mkdir -p /app
 ln -sf /db /app/db
 
+# Set up timezone for Alpine Linux
+if [ -n "$TZ" ]; then
+  # Create the timezone file if it doesn't exist
+  echo "$TZ" > /etc/TZ
+  # Create a symlink to the zoneinfo file if it exists
+  if [ -f "/usr/share/zoneinfo/$TZ" ]; then
+    ln -sf "/usr/share/zoneinfo/$TZ" /etc/localtime
+  fi
+fi
+
 echo "Generating Prisma client..."
 DATABASE_URL="file:/db/baby-tracker.db" npx prisma generate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",
         "@tailwindcss/postcss": "^4.0.17",
         "@types/jsonwebtoken": "^9.0.9",
-        "@types/node": "^22.13.4",
+        "@types/node": "^22.14.1",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "autoprefixer": "^10.4.20",
@@ -2557,13 +2557,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/react": {
@@ -8346,9 +8346,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baby-tracker",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baby-tracker",
-      "version": "0.9.0",
+      "version": "0.9.3",
       "dependencies": {
         "@lucide/lab": "^0.1.2",
         "@prisma/client": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",
     "@tailwindcss/postcss": "^4.0.17",
     "@types/jsonwebtoken": "^9.0.9",
-    "@types/node": "^22.13.4",
+    "@types/node": "^22.14.1",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baby-tracker",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## v0.9.3 (Beta Patch) - April 2025

### Changes

- Fixed an issue where etc/timezones isn't available in docker images
- Added the ability to set cookie auth to require HTTPS or not.  This is added to the .env file.  When enabled the cookie will only be valid and sent when the app is accessed over HTTPS.  When set to false the cookie will be valid and sent over HTTP or HTTPS.  IMPORTANT: When setting this to true you must have an SSL certificate in place otherwise all main API's will be blocked.
- Added the ability to disable Next.js telemetry collection in the setup scripts