### PR TITLE
Fix breast milk inventory balance for immediately consumed pumps

### DIFF
--- a/app/api/breast-milk-balance/route.ts
+++ b/app/api/breast-milk-balance/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import prisma from '../db';
 import { ApiResponse, BreastMilkBalanceResponse } from '../types';
 import { withAuthContext, AuthResult } from '../utils/auth';
-import { convertVolume } from '@/src/utils/unit-conversion';
+import { calculateBreastMilkBalance } from '@/src/utils/breastMilkInventory';
 
 async function handleGet(req: NextRequest, authContext: AuthResult) {
   try {
@@ -36,15 +36,8 @@ async function handleGet(req: NextRequest, authContext: AuthResult) {
         pumpAction: 'STORED',
         deletedAt: null,
       },
-      select: { totalAmount: true, unitAbbr: true },
+      select: { totalAmount: true, unitAbbr: true, pumpAction: true },
     });
-
-    let storedTotal = 0;
-    for (const log of pumpLogs) {
-      if (log.totalAmount) {
-        storedTotal += convertVolume(log.totalAmount, log.unitAbbr || 'OZ', targetUnit);
-      }
-    }
 
     // 2. Sum of breast milk adjustments
     const adjustments = await prisma.breastMilkAdjustment.findMany({
@@ -56,11 +49,6 @@ async function handleGet(req: NextRequest, authContext: AuthResult) {
       select: { amount: true, unitAbbr: true },
     });
 
-    let adjustmentTotal = 0;
-    for (const adj of adjustments) {
-      adjustmentTotal += convertVolume(adj.amount, adj.unitAbbr || 'OZ', targetUnit);
-    }
-
     // 3. Sum of bottle feeds with bottleType "Breast Milk" or "Formula\Breast"
     const feedLogs = await prisma.feedLog.findMany({
       where: {
@@ -70,20 +58,15 @@ async function handleGet(req: NextRequest, authContext: AuthResult) {
         bottleType: { in: ['Breast Milk', 'Formula\\Breast'] },
         deletedAt: null,
       },
-      select: { amount: true, unitAbbr: true, bottleType: true, breastMilkAmount: true },
+      select: { amount: true, unitAbbr: true, bottleType: true, breastMilkAmount: true, sourcePumpId: true, notes: true },
     });
 
-    let consumedTotal = 0;
-    for (const log of feedLogs) {
-      if (log.bottleType === 'Breast Milk' && log.amount) {
-        consumedTotal += convertVolume(log.amount, log.unitAbbr || 'OZ', targetUnit);
-      } else if (log.bottleType === 'Formula\\Breast' && log.breastMilkAmount) {
-        consumedTotal += convertVolume(log.breastMilkAmount, log.unitAbbr || 'OZ', targetUnit);
-      }
-    }
-
-    // Calculate balance: stored + adjustments - consumed
-    const balance = Math.round((storedTotal + adjustmentTotal - consumedTotal) * 100) / 100;
+    const balance = calculateBreastMilkBalance({
+      pumpLogs,
+      adjustments,
+      feedLogs,
+      targetUnit,
+    });
 
     return NextResponse.json<ApiResponse<BreastMilkBalanceResponse>>({
       success: true,

--- a/app/api/feed-log/route.ts
+++ b/app/api/feed-log/route.ts
@@ -153,7 +153,7 @@ async function handlePut(req: NextRequest, authContext: AuthResult) {
       ...(body.bottleType && body.bottleType.trim() ? { bottleType: body.bottleType } : { bottleType: null }),
       ...(body.breastMilkAmount !== undefined ? { breastMilkAmount: body.breastMilkAmount } : {}),
       ...Object.entries(body)
-        .filter(([key]) => !['time', 'startTime', 'endTime', 'feedDuration', 'notes', 'bottleType', 'breastMilkAmount', 'familyId'].includes(key))
+        .filter(([key]) => !['time', 'startTime', 'endTime', 'feedDuration', 'notes', 'bottleType', 'breastMilkAmount', 'familyId', 'sourcePumpId'].includes(key))
         .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {}),
     };
 

--- a/app/api/pump-log/route.ts
+++ b/app/api/pump-log/route.ts
@@ -5,6 +5,7 @@ import { withAuthContext, AuthResult } from '../utils/auth';
 import { toUTC, formatForResponse, calculateDurationMinutes } from '../utils/timezone';
 import { checkWritePermission } from '../utils/writeProtection';
 import { notifyActivityCreated } from '@/src/lib/notifications/activityHook';
+import { autoPumpFeedNotes, AUTO_PUMP_FEED_PREFIX } from '@/src/utils/breastMilkInventory';
 
 async function handlePost(req: NextRequest, authContext: AuthResult) {
   // Check write permissions for expired accounts
@@ -41,7 +42,7 @@ async function handlePost(req: NextRequest, authContext: AuthResult) {
     
     // Calculate total amount if not provided but left and right amounts are
     let totalAmount = body.totalAmount;
-    if (!totalAmount && (body.leftAmount || body.rightAmount)) {
+    if (totalAmount === undefined && (body.leftAmount !== undefined || body.rightAmount !== undefined)) {
       totalAmount = (body.leftAmount || 0) + (body.rightAmount || 0);
     }
     
@@ -51,47 +52,51 @@ async function handlePost(req: NextRequest, authContext: AuthResult) {
       return NextResponse.json<ApiResponse<null>>({ success: false, error: 'Invalid pump action. Must be STORED, FED, or DISCARDED.' }, { status: 400 });
     }
 
-    const pumpLog = await prisma.pumpLog.create({
-      data: {
-        babyId: body.babyId,
-        startTime: startTimeUTC,
-        endTime: endTimeUTC,
-        duration,
-        leftAmount: body.leftAmount,
-        rightAmount: body.rightAmount,
-        totalAmount,
-        unitAbbr: body.unitAbbr,
-        pumpAction,
-        notes: body.notes,
-        caretakerId: caretakerId,
-        familyId: userFamilyId,
-      },
-    });
-
-    // If pump action is "FED", auto-create a bottle feed log (only when breast milk tracking is enabled)
     const familySettings = await prisma.settings.findFirst({
       where: { familyId: userFamilyId },
       select: { enableBreastMilkTracking: true },
     });
-    if (familySettings?.enableBreastMilkTracking !== false && pumpAction === 'FED' && totalAmount) {
-      try {
-        await prisma.feedLog.create({
+    const trackingEnabled = familySettings?.enableBreastMilkTracking !== false;
+
+    const pumpLog = await prisma.$transaction(async (tx) => {
+      const createdPumpLog = await tx.pumpLog.create({
+        data: {
+          babyId: body.babyId,
+          startTime: startTimeUTC,
+          endTime: endTimeUTC,
+          duration,
+          leftAmount: body.leftAmount,
+          rightAmount: body.rightAmount,
+          totalAmount,
+          unitAbbr: body.unitAbbr,
+          pumpAction,
+          notes: body.notes,
+          caretakerId: caretakerId,
+          familyId: userFamilyId,
+        },
+      });
+
+      // Keep the feeding record for reports, but link it to the pump so it can
+      // be synchronized and excluded from stored-inventory consumption.
+      if (trackingEnabled && pumpAction === 'FED' && typeof totalAmount === 'number' && totalAmount > 0) {
+        await tx.feedLog.create({
           data: {
             time: startTimeUTC,
             type: 'BOTTLE',
             amount: totalAmount,
             unitAbbr: body.unitAbbr || 'OZ',
             bottleType: 'Breast Milk',
-            notes: body.notes ? `Auto-created from pump: ${body.notes}` : 'Auto-created from pump session',
+            notes: autoPumpFeedNotes(body.notes),
+            sourcePumpId: createdPumpLog.id,
             babyId: body.babyId,
             caretakerId: caretakerId,
             familyId: userFamilyId,
           },
         });
-      } catch (feedError) {
-        console.error('Error auto-creating feed log from pump:', feedError);
       }
-    }
+
+      return createdPumpLog;
+    });
 
     // Format dates as ISO strings for response
     const response: PumpLogResponse = {
@@ -208,9 +213,86 @@ async function handlePut(req: NextRequest, authContext: AuthResult) {
       data.pumpAction = body.pumpAction;
     }
 
-    const pumpLog = await prisma.pumpLog.update({
-      where: { id },
-      data,
+    const finalStartTime = body.startTime ? toUTC(body.startTime) : existingPumpLog.startTime;
+    const finalTotalAmount = body.totalAmount !== undefined
+      ? body.totalAmount
+      : (body.leftAmount !== undefined || body.rightAmount !== undefined)
+        ? (body.leftAmount !== undefined ? body.leftAmount : existingPumpLog.leftAmount || 0) +
+          (body.rightAmount !== undefined ? body.rightAmount : existingPumpLog.rightAmount || 0)
+        : existingPumpLog.totalAmount;
+    const finalPumpAction = body.pumpAction ?? existingPumpLog.pumpAction;
+    const finalUnitAbbr = body.unitAbbr !== undefined ? body.unitAbbr : existingPumpLog.unitAbbr;
+    const finalNotes = body.notes !== undefined ? body.notes : existingPumpLog.notes;
+    const finalBabyId = body.babyId !== undefined ? body.babyId : existingPumpLog.babyId;
+
+    const familySettings = await prisma.settings.findFirst({
+      where: { familyId: userFamilyId },
+      select: { enableBreastMilkTracking: true },
+    });
+    const trackingEnabled = familySettings?.enableBreastMilkTracking !== false;
+
+    const pumpLog = await prisma.$transaction(async (tx) => {
+      const linkedAutoFeed = await tx.feedLog.findFirst({
+        where: {
+          sourcePumpId: id,
+          familyId: userFamilyId,
+          babyId: existingPumpLog.babyId,
+        },
+      });
+      const legacyAutoFeed = linkedAutoFeed ? null : await tx.feedLog.findFirst({
+        where: {
+          sourcePumpId: null,
+          babyId: existingPumpLog.babyId,
+          familyId: userFamilyId,
+          time: existingPumpLog.startTime,
+          type: 'BOTTLE',
+          bottleType: 'Breast Milk',
+          ...(existingPumpLog.totalAmount != null ? { amount: existingPumpLog.totalAmount } : {}),
+          notes: { startsWith: AUTO_PUMP_FEED_PREFIX },
+          deletedAt: null,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      const updatedPumpLog = await tx.pumpLog.update({
+        where: { id },
+        data,
+      });
+
+      const autoFeedId = linkedAutoFeed?.id || legacyAutoFeed?.id;
+      const shouldHaveAutoFeed = trackingEnabled && finalPumpAction === 'FED' &&
+        typeof finalTotalAmount === 'number' && finalTotalAmount > 0;
+
+      if (shouldHaveAutoFeed) {
+        const feedData = {
+          time: finalStartTime,
+          type: 'BOTTLE' as const,
+          amount: finalTotalAmount,
+          unitAbbr: finalUnitAbbr || 'OZ',
+          bottleType: 'Breast Milk',
+          notes: autoPumpFeedNotes(finalNotes),
+          sourcePumpId: id,
+          deletedAt: null,
+          babyId: finalBabyId,
+          caretakerId: existingPumpLog.caretakerId,
+          familyId: userFamilyId,
+        };
+
+        if (autoFeedId) {
+          await tx.feedLog.update({ where: { id: autoFeedId }, data: feedData });
+        } else {
+          await tx.feedLog.create({ data: feedData });
+        }
+      } else {
+        if (linkedAutoFeed) {
+          await tx.feedLog.delete({ where: { id: linkedAutoFeed.id } });
+        }
+        if (legacyAutoFeed) {
+          await tx.feedLog.delete({ where: { id: legacyAutoFeed.id } });
+        }
+      }
+
+      return updatedPumpLog;
     });
 
     // Format dates as ISO strings for response
@@ -374,9 +456,37 @@ async function handleDelete(req: NextRequest, authContext: AuthResult) {
       );
     }
 
-    // Hard delete the record
-    await prisma.pumpLog.delete({
-      where: { id },
+    await prisma.$transaction(async (tx) => {
+      const linkedAutoFeed = await tx.feedLog.findFirst({
+        where: {
+          sourcePumpId: id,
+          familyId: userFamilyId,
+          babyId: existingPumpLog.babyId,
+        },
+      });
+      const legacyAutoFeed = linkedAutoFeed ? null : await tx.feedLog.findFirst({
+        where: {
+          sourcePumpId: null,
+          babyId: existingPumpLog.babyId,
+          familyId: userFamilyId,
+          time: existingPumpLog.startTime,
+          type: 'BOTTLE',
+          bottleType: 'Breast Milk',
+          ...(existingPumpLog.totalAmount != null ? { amount: existingPumpLog.totalAmount } : {}),
+          notes: { startsWith: AUTO_PUMP_FEED_PREFIX },
+          deletedAt: null,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      if (linkedAutoFeed) {
+        await tx.feedLog.delete({ where: { id: linkedAutoFeed.id } });
+      }
+      if (legacyAutoFeed) {
+        await tx.feedLog.delete({ where: { id: legacyAutoFeed.id } });
+      }
+
+      await tx.pumpLog.delete({ where: { id } });
     });
 
     return NextResponse.json<ApiResponse<void>>({

--- a/prisma/migrations/20260714000000_add_source_pump_id_to_feed_log/migration.sql
+++ b/prisma/migrations/20260714000000_add_source_pump_id_to_feed_log/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "FeedLog" ADD COLUMN "sourcePumpId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FeedLog_sourcePumpId_key" ON "FeedLog"("sourcePumpId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -369,6 +369,7 @@ model FeedLog {
   bottleType   String? // Type of bottle feed: formula, breast milk, formula\breast, milk, other
   breastMilkAmount Float? // Breast milk amount used (for Formula\Breast mixed feeds)
   sessionId    String? // Groups breast feeds into one nursing session; a unique value opts a feed out of heuristic grouping
+  sourcePumpId String? @unique // Links an automatic breast-milk feed to the pump session that created it
   createdAt    DateTime    @default(now())
   updatedAt    DateTime    @updatedAt
   deletedAt    DateTime?

--- a/src/components/Reports/PumpingChartModal.tsx
+++ b/src/components/Reports/PumpingChartModal.tsx
@@ -23,6 +23,7 @@ import { useLocalization } from '@/src/context/localization';
 import { useTimezone } from '@/app/context/timezone';
 import { formatDateShort, formatDateDisplay } from '@/src/utils/dateFormat';
 import { convertVolume } from '@/src/utils/unit-conversion';
+import { isAutoCreatedPumpFeed } from '@/src/utils/breastMilkInventory';
 
 export type PumpingChartMetric = 'count' | 'duration' | 'amount' | 'inventory';
 
@@ -236,7 +237,7 @@ const PumpingChartModal: React.FC<PumpingChartModalProps> = ({
     const endDate = new Date(dateRange.to);
     endDate.setHours(23, 59, 59, 999);
 
-    const targetUnit = 'OZ';
+    const targetUnit = currentBalance.unit.toUpperCase();
 
     // Collect all inventory events with their dates and effects on balance
     const eventsByDay: Record<string, { consumed: number; stored: number; adjusted: number }> = {};
@@ -245,7 +246,7 @@ const PumpingChartModal: React.FC<PumpingChartModalProps> = ({
       // Bottle feeds with breast milk = consumed
       if ('type' in activity && 'time' in activity && 'bottleType' in activity) {
         const feedActivity = activity as any;
-        if (feedActivity.type === 'BOTTLE') {
+        if (feedActivity.type === 'BOTTLE' && !isAutoCreatedPumpFeed(feedActivity)) {
           let bmConsumed = 0;
           if (feedActivity.bottleType === 'Breast Milk' && feedActivity.amount) {
             bmConsumed = convertVolume(feedActivity.amount, feedActivity.unitAbbr || 'OZ', targetUnit);
@@ -621,10 +622,10 @@ const PumpingChartModal: React.FC<PumpingChartModalProps> = ({
                     <RechartsTooltip
                       formatter={(value: any, name?: string) => {
                         if (name === 'consumed') {
-                          return [`${value.toFixed(1)} oz`, t('Consumed')];
+                          return [`${value.toFixed(1)} ${(currentBalance?.unit || 'OZ').toLowerCase()}`, t('Consumed')];
                         }
                         if (name === 'storedBalance') {
-                          return [`${value.toFixed(1)} oz`, t('Stored Balance')];
+                          return [`${value.toFixed(1)} ${(currentBalance?.unit || 'OZ').toLowerCase()}`, t('Stored Balance')];
                         }
                         return [`${value.toFixed(1)}`, name || ''];
                       }}
@@ -672,4 +673,3 @@ const PumpingChartModal: React.FC<PumpingChartModalProps> = ({
 };
 
 export default PumpingChartModal;
-

--- a/src/components/Reports/PumpingStatsSection.tsx
+++ b/src/components/Reports/PumpingStatsSection.tsx
@@ -78,7 +78,7 @@ const PumpingStatsSection: React.FC<PumpingStatsSectionProps> = ({ stats, activi
       }
     };
     fetchBalance();
-  }, [selectedBaby, stats.unit, enableBreastMilkTracking]);
+  }, [selectedBaby, stats.unit, enableBreastMilkTracking, activities]);
 
   return (
     <>
@@ -178,4 +178,3 @@ const PumpingStatsSection: React.FC<PumpingStatsSectionProps> = ({ stats, activi
 };
 
 export default PumpingStatsSection;
-

--- a/src/utils/breastMilkInventory.ts
+++ b/src/utils/breastMilkInventory.ts
@@ -1,0 +1,72 @@
+import { convertVolume } from './unit-conversion';
+
+export const AUTO_PUMP_FEED_PREFIX = 'Auto-created from pump';
+
+export interface BreastMilkPumpInventoryRow {
+  totalAmount: number | null;
+  unitAbbr: string | null;
+  pumpAction: string;
+}
+
+export interface BreastMilkAdjustmentInventoryRow {
+  amount: number;
+  unitAbbr: string | null;
+}
+
+export interface BreastMilkFeedInventoryRow {
+  amount: number | null;
+  unitAbbr: string | null;
+  bottleType: string | null;
+  breastMilkAmount: number | null;
+  sourcePumpId?: string | null;
+  notes?: string | null;
+}
+
+export function autoPumpFeedNotes(notes?: string | null): string {
+  return notes ? `${AUTO_PUMP_FEED_PREFIX}: ${notes}` : `${AUTO_PUMP_FEED_PREFIX} session`;
+}
+
+export function isAutoCreatedPumpFeed(feed: Pick<BreastMilkFeedInventoryRow, 'sourcePumpId' | 'notes'>): boolean {
+  return Boolean(
+    feed.sourcePumpId ||
+      (typeof feed.notes === 'string' && feed.notes.startsWith(AUTO_PUMP_FEED_PREFIX))
+  );
+}
+
+export function calculateBreastMilkBalance({
+  pumpLogs,
+  adjustments,
+  feedLogs,
+  targetUnit,
+}: {
+  pumpLogs: BreastMilkPumpInventoryRow[];
+  adjustments: BreastMilkAdjustmentInventoryRow[];
+  feedLogs: BreastMilkFeedInventoryRow[];
+  targetUnit: string;
+}): number {
+  const storedTotal = pumpLogs.reduce((total, log) => {
+    if (log.pumpAction !== 'STORED' || log.totalAmount == null) return total;
+    return total + convertVolume(log.totalAmount, log.unitAbbr || 'OZ', targetUnit);
+  }, 0);
+
+  const adjustmentTotal = adjustments.reduce(
+    (total, adjustment) => total + convertVolume(adjustment.amount, adjustment.unitAbbr || 'OZ', targetUnit),
+    0
+  );
+
+  const consumedTotal = feedLogs.reduce((total, log) => {
+    if (isAutoCreatedPumpFeed(log)) return total;
+
+    if (log.bottleType === 'Breast Milk' && log.amount != null) {
+      return total + convertVolume(log.amount, log.unitAbbr || 'OZ', targetUnit);
+    }
+
+    if (log.bottleType === 'Formula\\Breast' && log.breastMilkAmount != null) {
+      return total + convertVolume(log.breastMilkAmount, log.unitAbbr || 'OZ', targetUnit);
+    }
+
+    return total;
+  }, 0);
+
+  return Math.round((storedTotal + adjustmentTotal - consumedTotal) * 100) / 100;
+}

--- a/tests/breastMilkInventory.test.ts
+++ b/tests/breastMilkInventory.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  autoPumpFeedNotes,
+  calculateBreastMilkBalance,
+  isAutoCreatedPumpFeed,
+} from '@/src/utils/breastMilkInventory';
+
+describe('breast milk inventory', () => {
+  it('does not count a pump-created FED feed as consumption from stored inventory', () => {
+    const balance = calculateBreastMilkBalance({
+      pumpLogs: [],
+      adjustments: [],
+      feedLogs: [
+        {
+          amount: 4,
+          unitAbbr: 'OZ',
+          bottleType: 'Breast Milk',
+          breastMilkAmount: null,
+          sourcePumpId: 'pump-1',
+          notes: autoPumpFeedNotes(),
+        },
+      ],
+      targetUnit: 'OZ',
+    });
+
+    expect(balance).toBe(0);
+  });
+
+  it('keeps manual breast-milk consumption in the balance calculation', () => {
+    const balance = calculateBreastMilkBalance({
+      pumpLogs: [{ totalAmount: 8, unitAbbr: 'OZ', pumpAction: 'STORED' }],
+      adjustments: [],
+      feedLogs: [
+        {
+          amount: 3,
+          unitAbbr: 'OZ',
+          bottleType: 'Breast Milk',
+          breastMilkAmount: null,
+          sourcePumpId: null,
+          notes: 'Manual feed',
+        },
+      ],
+      targetUnit: 'OZ',
+    });
+
+    expect(balance).toBe(5);
+  });
+
+  it('uses only the breast-milk portion of a mixed bottle and converts units', () => {
+    const balance = calculateBreastMilkBalance({
+      pumpLogs: [{ totalAmount: 300, unitAbbr: 'ML', pumpAction: 'STORED' }],
+      adjustments: [],
+      feedLogs: [
+        {
+          amount: 6,
+          unitAbbr: 'ML',
+          bottleType: 'Formula\\Breast',
+          breastMilkAmount: 2,
+          sourcePumpId: null,
+          notes: null,
+        },
+      ],
+      targetUnit: 'ML',
+    });
+
+    expect(balance).toBe(298);
+  });
+
+  it('recognizes legacy automatic feeds by their existing note prefix', () => {
+    expect(isAutoCreatedPumpFeed({ sourcePumpId: null, notes: 'Auto-created from pump session' })).toBe(true);
+    expect(isAutoCreatedPumpFeed({ sourcePumpId: null, notes: 'Manual feed' })).toBe(false);
+  });
+
+  it('does not count legacy pump-created feeds as consumption', () => {
+    const balance = calculateBreastMilkBalance({
+      pumpLogs: [{ totalAmount: 5, unitAbbr: 'OZ', pumpAction: 'STORED' }],
+      adjustments: [],
+      feedLogs: [
+        {
+          amount: 2,
+          unitAbbr: 'OZ',
+          bottleType: 'Breast Milk',
+          breastMilkAmount: null,
+          sourcePumpId: null,
+          notes: 'Auto-created from pump: immediately consumed',
+        },
+      ],
+      targetUnit: 'OZ',
+    });
+
+    expect(balance).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

- Link automatic bottle feeds to the pump session that created them.
- Exclude immediately consumed pump sessions from stored inventory consumption.
- Synchronize automatic feeds when pump sessions are edited or deleted.
- Keep linked feed operations scoped to the authenticated family and protect sourcePumpId from client writes.
- Add unit-aware inventory chart calculations and regression tests.

## Validation

- npm test -- --reporter=dot
- npx tsc --noEmit --pretty false
- npx prisma validate
- git diff --check

Closes #204