### PR TITLE
fix: persist bottle volume unit when PWA resumes

### DIFF
--- a/app/(app)/[slug]/client-layout.tsx
+++ b/app/(app)/[slug]/client-layout.tsx
@@ -30,6 +30,7 @@ import { Loader2 } from 'lucide-react';
 import AccountExpirationBanner from '@/src/components/ui/account-expiration-banner';
 import NotificationSplashModal from '@/src/components/modals/NotificationSplashModal';
 import { checkPushSupport, checkSubscriptionStatus } from '@/src/lib/notifications/client';
+import { cacheDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
 // Loading fallback is a component so it can use the localization hook
 const PaymentModalLoading = () => {
   const { t } = useLocalization();
@@ -167,12 +168,16 @@ function AppContent({ children }: { children: React.ReactNode }) {
       }
       
       const settingsResponse = await fetch(settingsUrl, {
+        cache: 'no-store',
         headers: authToken ? {
           'Authorization': `Bearer ${authToken}`
         } : {}
       });
       if (settingsResponse.ok) {
         const settingsData = await settingsResponse.json();
+        if (settingsData.success) {
+          cacheDefaultBottleUnit(settingsData.data?.defaultBottleUnit);
+        }
         if (settingsData.success && settingsData.data.familyName) {
           setFamilyName(settingsData.data.familyName);
         }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -54,7 +54,7 @@ async function handleGet(req: NextRequest, authContext: AuthResult) {
     return NextResponse.json<ApiResponse<SettingsResponse>>({
       success: true,
       data: toSettingsResponse(settings),
-    });
+    }, { headers: { 'Cache-Control': 'no-store, max-age=0' } });
   } catch (error) {
     console.error('Error fetching settings:', error);
     return NextResponse.json<ApiResponse<SettingsResponse>>(
@@ -193,7 +193,7 @@ async function handlePut(req: NextRequest, authContext: AuthResult) {
     return NextResponse.json<ApiResponse<SettingsResponse>>({
       success: true,
       data: toSettingsResponse(settings),
-    });
+    }, { headers: { 'Cache-Control': 'no-store, max-age=0' } });
   } catch (error) {
     console.error('Error updating settings:', error);
     return NextResponse.json<ApiResponse<SettingsResponse>>(

--- a/src/components/Timeline/TimelineV2/index.tsx
+++ b/src/components/Timeline/TimelineV2/index.tsx
@@ -23,9 +23,11 @@ import { groupBreastFeedSessions } from '@/src/utils/feedSessionUtils';
 import { SleepLogResponse, FeedLogResponse, DiaperLogResponse, PumpLogResponse, BreastMilkAdjustmentResponse, PlayLogResponse, VaccineLogResponse, PhotoResponse } from '@/app/api/types';
 import { fetchPhotos } from '@/src/utils/photoClientApi';
 import { useActivityCache } from './useActivityCache';
+import { cacheDefaultBottleUnit, readCachedDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
 
 const TimelineV2 = ({ babyId, refreshTrigger, onLatestStatusReady, onActivityDeleted }: TimelineProps) => {
   const [settings, setSettings] = useState<Settings | null>(null);
+  const [defaultBottleUnit, setDefaultBottleUnit] = useState(() => readCachedDefaultBottleUnit());
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoResponse | null>(null);
   const [activeFilter, setActiveFilter] = useState<FilterType>(null);
@@ -130,7 +132,7 @@ const TimelineV2 = ({ babyId, refreshTrigger, onLatestStatusReady, onActivityDel
     }
     try {
       const authToken = localStorage.getItem('authToken');
-      const unit = settings?.defaultBottleUnit || 'OZ';
+      const unit = settings?.defaultBottleUnit || defaultBottleUnit;
       const response = await fetch(`/api/breast-milk-balance?babyId=${babyId}&unit=${unit}`, {
         headers: {
           ...(authToken ? { 'Authorization': `Bearer ${authToken}` } : {})
@@ -270,24 +272,42 @@ const TimelineV2 = ({ babyId, refreshTrigger, onLatestStatusReady, onActivityDel
     setActiveFilter(activeFilter === filter ? null : filter);
   };
 
-  // Fetch settings
-  useEffect(() => {
-    const fetchSettings = async () => {
+  // Fetch settings and refresh them when a warm PWA becomes active again.
+  const refreshSettings = useCallback(async () => {
+    try {
       const authToken = localStorage.getItem('authToken');
       const response = await fetch('/api/settings', {
+        cache: 'no-store',
         headers: {
           'Authorization': authToken ? `Bearer ${authToken}` : '',
         },
       });
-      if (response.ok) {
-        const data = await response.json();
-        if (data.success) {
-          setSettings(data.data);
-        }
+      if (!response.ok) return;
+
+      const data = await response.json();
+      if (data.success) {
+        setSettings(data.data);
+        const unit = cacheDefaultBottleUnit(data.data?.defaultBottleUnit);
+        if (unit) setDefaultBottleUnit(unit);
       }
-    };
-    fetchSettings();
+    } catch (error) {
+      console.error('Error fetching settings:', error);
+    }
   }, []);
+
+  useEffect(() => {
+    refreshSettings();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refreshSettings();
+    };
+    window.addEventListener('focus', refreshSettings);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', refreshSettings);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [refreshSettings]);
 
   // Initial fetch when babyId changes
   useEffect(() => {
@@ -302,7 +322,7 @@ const TimelineV2 = ({ babyId, refreshTrigger, onLatestStatusReady, onActivityDel
     if (babyId) {
       fetchBreastMilkBalance(babyId);
     }
-  }, [babyId, settings?.defaultBottleUnit]);
+  }, [babyId, settings?.defaultBottleUnit, defaultBottleUnit]);
 
   // Handle refreshTrigger from parent (form submissions in log-entry page)
   useEffect(() => {
@@ -474,7 +494,7 @@ const TimelineV2 = ({ babyId, refreshTrigger, onLatestStatusReady, onActivityDel
         isHeatmapVisible={isHeatmapVisible}
         onHeatmapToggle={() => setIsHeatmapVisible((prev) => !prev)}
         breastMilkBalance={breastMilkTrackingEnabled ? breastMilkBalance : undefined}
-        defaultBottleUnit={settings?.defaultBottleUnit}
+        defaultBottleUnit={settings?.defaultBottleUnit || defaultBottleUnit}
         enableBreastMilkTracking={breastMilkTrackingEnabled}
       />
 

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -19,9 +19,11 @@ import TimelineActivityList from './TimelineActivityList';
 import TimelineActivityDetails from './TimelineActivityDetails';
 import { getActivityEndpoint, getActivityTime } from './utils';
 import { PumpLogResponse, BreastMilkAdjustmentResponse, PlayLogResponse, VaccineLogResponse } from '@/app/api/types';
+import { cacheDefaultBottleUnit, readCachedDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
 
 const Timeline = ({ activities, onActivityDeleted }: LegacyTimelineProps) => {
   const [settings, setSettings] = useState<Settings | null>(null);
+  const [defaultBottleUnit, setDefaultBottleUnit] = useState(() => readCachedDefaultBottleUnit());
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [activeFilter, setActiveFilter] = useState<FilterType>(null);
   const [editModalType, setEditModalType] = useState<'sleep' | 'feed' | 'diaper' | 'medicine' | 'note' | 'bath' | 'pump' | 'breast-milk-adjustment' | 'milestone' | 'measurement' | 'play' | 'vaccine' | 'photo' | null>(null);
@@ -102,7 +104,7 @@ const Timeline = ({ activities, onActivityDeleted }: LegacyTimelineProps) => {
     }
     try {
       const authToken = localStorage.getItem('authToken');
-      const unit = settings?.defaultBottleUnit || 'OZ';
+      const unit = settings?.defaultBottleUnit || defaultBottleUnit;
       const response = await fetch(`/api/breast-milk-balance?babyId=${babyId}&unit=${unit}`, {
         headers: {
           ...(authToken ? { 'Authorization': `Bearer ${authToken}` } : {})
@@ -155,6 +157,7 @@ const Timeline = ({ activities, onActivityDeleted }: LegacyTimelineProps) => {
     const fetchSettings = async () => {
       const authToken = localStorage.getItem('authToken');
       const response = await fetch('/api/settings', {
+        cache: 'no-store',
         headers: {
           'Authorization': authToken ? `Bearer ${authToken}` : '',
         },
@@ -163,6 +166,8 @@ const Timeline = ({ activities, onActivityDeleted }: LegacyTimelineProps) => {
         const data = await response.json();
         if (data.success) {
           setSettings(data.data);
+          const unit = cacheDefaultBottleUnit(data.data?.defaultBottleUnit);
+          if (unit) setDefaultBottleUnit(unit);
         }
       }
     };
@@ -181,7 +186,7 @@ const Timeline = ({ activities, onActivityDeleted }: LegacyTimelineProps) => {
     if (babyId) {
       fetchBreastMilkBalance(babyId);
     }
-  }, [babyId, settings?.defaultBottleUnit]);
+  }, [babyId, settings?.defaultBottleUnit, defaultBottleUnit]);
 
   useEffect(() => {
     if (!babyId) return;

--- a/src/components/features/nursery-mode/activities/useFeedActions.ts
+++ b/src/components/features/nursery-mode/activities/useFeedActions.ts
@@ -5,6 +5,8 @@ import { useLocalization } from '@/src/context/localization';
 import { ActiveBreastFeedResponse } from '@/app/api/types';
 import { formatFeedNote, FeedNoteLabels } from '@/src/utils/nursery/activityDetail';
 import { ActivityHookArgs, ActivityView, ActionButton, formatMMSS, undoDeleteLog } from './types';
+import { cacheDefaultBottleUnit, readCachedDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
+import type { BottleUnit } from '@/src/utils/defaultBottleUnit';
 
 type FeedPhase = 'idle' | 'feeding' | 'paused';
 
@@ -16,11 +18,23 @@ type FeedPhase = 'idle' | 'feeding' | 'paused';
 export function useFeedActions({ babyId, toUTCString, onLog, onUndoable }: ActivityHookArgs): ActivityView {
   const { t } = useLocalization();
   const [avgBottleAmount, setAvgBottleAmount] = useState<number | null>(null);
-  const [defaultUnit, setDefaultUnit] = useState('OZ');
+  const [defaultUnit, setDefaultUnit] = useState<BottleUnit>(() => readCachedDefaultBottleUnit());
   const [submitting, setSubmitting] = useState(false);
   const [phase, setPhase] = useState<FeedPhase>('idle');
   const [activeFeed, setActiveFeed] = useState<ActiveBreastFeedResponse | null>(null);
   const [currentElapsed, setCurrentElapsed] = useState(0);
+
+  const refreshDefaultUnit = useCallback(async () => {
+    const authToken = localStorage.getItem('authToken');
+    const headers = { Authorization: authToken ? `Bearer ${authToken}` : '' };
+
+    try {
+      const settingsRes = await fetch('/api/settings', { headers, cache: 'no-store' });
+      const settingsData = await settingsRes.json();
+      const unit = cacheDefaultBottleUnit(settingsData.success && settingsData.data?.defaultBottleUnit);
+      if (unit) setDefaultUnit(unit);
+    } catch { /* keep the cached/default unit */ }
+  }, []);
 
   // Fetch bottle defaults
   useEffect(() => {
@@ -28,13 +42,7 @@ export function useFeedActions({ babyId, toUTCString, onLog, onUndoable }: Activ
       const authToken = localStorage.getItem('authToken');
       const headers = { Authorization: authToken ? `Bearer ${authToken}` : '' };
 
-      try {
-        const settingsRes = await fetch('/api/settings', { headers });
-        const settingsData = await settingsRes.json();
-        if (settingsData.success && settingsData.data?.defaultBottleUnit) {
-          setDefaultUnit(settingsData.data.defaultBottleUnit);
-        }
-      } catch { /* use default */ }
+      await refreshDefaultUnit();
 
       try {
         const feedRes = await fetch(`/api/feed-log?babyId=${babyId}&type=BOTTLE`, { headers });
@@ -53,7 +61,22 @@ export function useFeedActions({ babyId, toUTCString, onLog, onUndoable }: Activ
     };
 
     if (babyId) fetchDefaults();
-  }, [babyId]);
+  }, [babyId, refreshDefaultUnit]);
+
+  // Android can resume a warm PWA without remounting its React tree. Re-read
+  // the server preference when the app becomes active again.
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refreshDefaultUnit();
+    };
+
+    window.addEventListener('focus', refreshDefaultUnit);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', refreshDefaultUnit);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [refreshDefaultUnit]);
 
   // Check for existing active breastfeed session on mount / baby change
   useEffect(() => {

--- a/src/components/features/nursery-mode/activities/usePumpActions.ts
+++ b/src/components/features/nursery-mode/activities/usePumpActions.ts
@@ -5,6 +5,8 @@ import { useLocalization } from '@/src/context/localization';
 import { formatPumpNote, PumpNoteLabels } from '@/src/utils/nursery/activityDetail';
 import { loadPumpSession, savePumpSession, clearPumpSession } from '@/src/utils/nursery/pumpSession';
 import { ActivityHookArgs, ActivityView, ActionButton, AmountPrompt, formatMMSS, undoDeleteLog } from './types';
+import { cacheDefaultBottleUnit, readCachedDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
+import type { BottleUnit } from '@/src/utils/defaultBottleUnit';
 
 type PumpSide = 'left' | 'right' | 'both';
 type PumpPhase = 'idle' | 'timing' | 'paused' | 'selecting_action';
@@ -26,23 +28,38 @@ export function usePumpActions({ babyId, toUTCString, onLog, onUndoable, enableB
   const [startTime, setStartTime] = useState<Date | null>(null);
   const [resumeTime, setResumeTime] = useState<number | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [defaultUnit, setDefaultUnit] = useState('OZ');
+  const [defaultUnit, setDefaultUnit] = useState<BottleUnit>(() => readCachedDefaultBottleUnit());
   const [amountLeft, setAmountLeft] = useState('');
   const [amountRight, setAmountRight] = useState('');
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
+  const refreshDefaultUnit = useCallback(async () => {
+    try {
+      const authToken = localStorage.getItem('authToken');
+      const res = await fetch('/api/settings', {
+        cache: 'no-store',
+        headers: { Authorization: authToken ? `Bearer ${authToken}` : '' },
+      });
+      const data = await res.json();
+      const unit = cacheDefaultBottleUnit(data.success && data.data?.defaultBottleUnit);
+      if (unit) setDefaultUnit(unit);
+    } catch { /* keep the cached/default unit */ }
+  }, []);
+
   // Fetch bottle/pump amount unit default (same setting FeedTile uses).
   useEffect(() => {
-    const fetchDefaultUnit = async () => {
-      try {
-        const authToken = localStorage.getItem('authToken');
-        const res = await fetch('/api/settings', { headers: { Authorization: authToken ? `Bearer ${authToken}` : '' } });
-        const data = await res.json();
-        if (data.success && data.data?.defaultBottleUnit) setDefaultUnit(data.data.defaultBottleUnit);
-      } catch { /* use default */ }
+    refreshDefaultUnit();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refreshDefaultUnit();
     };
-    fetchDefaultUnit();
-  }, []);
+    window.addEventListener('focus', refreshDefaultUnit);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', refreshDefaultUnit);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [refreshDefaultUnit]);
 
   // Guards the persistence effect below against writing a stale ('idle') snapshot
   // in the same render pass this rehydration effect fires in — state updates from

--- a/src/components/forms/FeedForm/index.tsx
+++ b/src/components/forms/FeedForm/index.tsx
@@ -19,6 +19,7 @@ import { handleExpirationError } from '@/src/lib/expiration-error-handler';
 import { newFeedSessionId } from '@/src/utils/feedSessionUtils';
 import { PhotoAttachments } from '@/src/components/ui/photo-attachments';
 import { uploadPhotos, linkPhoto, unlinkPhoto, fetchPhotos, fetchPhotosEnabled } from '@/src/utils/photoClientApi';
+import { cacheDefaultBottleUnit, readCachedDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
 import './feed-form.css';
 
 // Import subcomponents
@@ -83,7 +84,7 @@ export default function FeedForm({
     time: initialTime,
     type: '' as FeedType | '',
     amount: '',
-    unit: 'OZ', // Default unit
+    unit: readCachedDefaultBottleUnit() as string,
     side: '' as BreastSide | '',
     food: '',
     notes: '',
@@ -100,7 +101,7 @@ export default function FeedForm({
   const [initializedTime, setInitializedTime] = useState<string | null>(null);
   const [validationError, setValidationError] = useState<string>('');
   const [defaultSettings, setDefaultSettings] = useState({
-    defaultBottleUnit: 'OZ',
+    defaultBottleUnit: readCachedDefaultBottleUnit() as string,
     defaultSolidsUnit: 'TBSP',
   });
 
@@ -258,6 +259,7 @@ export default function FeedForm({
     try {
       const authToken = localStorage.getItem('authToken');
       const response = await fetch('/api/settings', {
+        cache: 'no-store',
         headers: {
           'Authorization': authToken ? `Bearer ${authToken}` : '',
         },
@@ -266,15 +268,16 @@ export default function FeedForm({
       
       const data = await response.json();
       if (data.success && data.data) {
+        const defaultBottleUnit = cacheDefaultBottleUnit(data.data.defaultBottleUnit) || 'OZ';
         setDefaultSettings({
-          defaultBottleUnit: data.data.defaultBottleUnit || 'OZ',
+          defaultBottleUnit,
           defaultSolidsUnit: data.data.defaultSolidsUnit || 'TBSP',
         });
         
         // Set the default unit from settings
         setFormData(prev => ({
           ...prev,
-          unit: data.data.defaultBottleUnit || 'OZ'
+          unit: defaultBottleUnit
         }));
       }
     } catch (error) {

--- a/src/components/forms/PumpForm/index.tsx
+++ b/src/components/forms/PumpForm/index.tsx
@@ -20,6 +20,7 @@ import { Switch } from '@/src/components/ui/switch';
 import { useLocalization } from '@/src/context/localization';
 import { BreastMilkAdjustmentResponse } from '@/app/api/types';
 import { useUnit } from '@/src/hooks/useUnit';
+import { cacheDefaultBottleUnit, readCachedDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
 
 import './pump-form.css';
 
@@ -51,7 +52,7 @@ export default function PumpForm({
   // Adjustment mode state
   const [isAdjustMode, setIsAdjustMode] = useState(false);
   const [adjustAmount, setAdjustAmount] = useState('');
-  const [adjustUnit, setAdjustUnit] = useState('OZ');
+  const [adjustUnit, setAdjustUnit] = useState<string>(() => readCachedDefaultBottleUnit());
   const [adjustIsAdding, setAdjustIsAdding] = useState(true);
   const [adjustReason, setAdjustReason] = useState('Initial Stock');
   const [adjustNotes, setAdjustNotes] = useState('');
@@ -99,7 +100,7 @@ export default function PumpForm({
     leftAmount: '',
     rightAmount: '',
     totalAmount: '',
-    unitAbbr: 'OZ', // Default unit
+    unitAbbr: readCachedDefaultBottleUnit() as string,
     notes: '',
   });
   const [loading, setLoading] = useState(false);
@@ -143,7 +144,7 @@ export default function PumpForm({
     if (isOpen && adjustmentActivity) {
       setIsAdjustMode(true);
       setAdjustAmount(Math.abs(adjustmentActivity.amount).toString());
-      setAdjustUnit(adjustmentActivity.unitAbbr || 'OZ');
+      setAdjustUnit(adjustmentActivity.unitAbbr || readCachedDefaultBottleUnit());
       setAdjustIsAdding(adjustmentActivity.amount >= 0);
       setAdjustReason(adjustmentActivity.reason || 'Other');
       setAdjustNotes(adjustmentActivity.notes || '');
@@ -203,7 +204,7 @@ export default function PumpForm({
           leftAmount: activity.leftAmount?.toString() || '',
           rightAmount: activity.rightAmount?.toString() || '',
           totalAmount: activity.totalAmount?.toString() || '',
-          unitAbbr: activity.unitAbbr || 'OZ',
+          unitAbbr: activity.unitAbbr || readCachedDefaultBottleUnit(),
           notes: activity.notes || '',
         });
       } else {
@@ -212,14 +213,19 @@ export default function PumpForm({
           try {
             const authToken = localStorage.getItem('authToken');
             const response = await fetch('/api/settings', {
+              cache: 'no-store',
               headers: {
                 'Authorization': authToken ? `Bearer ${authToken}` : '',
               },
             });
             if (!response.ok) return;
             const data = await response.json();
-            if (data.success && data.data?.defaultBottleUnit) {
-              setFormData(prev => ({ ...prev, unitAbbr: data.data.defaultBottleUnit }));
+            if (data.success && data.data) {
+              const defaultBottleUnit = cacheDefaultBottleUnit(data.data.defaultBottleUnit);
+              if (defaultBottleUnit) {
+                setFormData(prev => ({ ...prev, unitAbbr: defaultBottleUnit }));
+                setAdjustUnit(defaultBottleUnit);
+              }
             }
             setBreastMilkTrackingEnabled(data.data?.enableBreastMilkTracking ?? true);
           } catch (error) {
@@ -281,12 +287,12 @@ export default function PumpForm({
         leftAmount: '',
         rightAmount: '',
         totalAmount: '',
-        unitAbbr: 'OZ',
+        unitAbbr: readCachedDefaultBottleUnit(),
         notes: '',
       });
       setPumpAction('STORED');
       setAdjustAmount('');
-      setAdjustUnit('OZ');
+      setAdjustUnit(readCachedDefaultBottleUnit());
       setAdjustIsAdding(true);
       setAdjustReason('Initial Stock');
       setAdjustNotes('');

--- a/src/components/forms/SettingsForm/index.tsx
+++ b/src/components/forms/SettingsForm/index.tsx
@@ -18,6 +18,7 @@ import ChangePinModal from '@/src/components/modals/ChangePinModal';
 import { useToast } from '@/src/components/ui/toast';
 import { handleExpirationError } from '@/src/lib/expiration-error-handler';
 import { useLocalization } from '@/src/context/localization';
+import { cacheDefaultBottleUnit } from '@/src/utils/defaultBottleUnit';
 import UserSettingsTab from './UserSettingsTab';
 import ConfigTab from './ConfigTab';
 import AdminTab from './AdminTab';
@@ -293,6 +294,7 @@ export default function SettingsForm({
       const data = await response.json();
       if (data.success) {
         setSettings(data.data);
+        cacheDefaultBottleUnit(data.data?.defaultBottleUnit);
       } else {
         showToast({
           variant: 'error',

--- a/src/utils/defaultBottleUnit.ts
+++ b/src/utils/defaultBottleUnit.ts
@@ -1,0 +1,56 @@
+export type BottleUnit = 'OZ' | 'ML';
+
+export const DEFAULT_BOTTLE_UNIT: BottleUnit = 'OZ';
+
+const STORAGE_KEY_PREFIX = 'sprout-track.defaultBottleUnit';
+
+function getStorageScope(): string {
+  if (typeof window === 'undefined') return 'server';
+
+  try {
+    const token = window.localStorage.getItem('authToken');
+    const encodedPayload = token?.split('.')[1];
+    if (encodedPayload) {
+      const base64 = encodedPayload.replace(/-/g, '+').replace(/_/g, '/');
+      const payload = JSON.parse(window.atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, '=')));
+      if (typeof payload.familyId === 'string' && payload.familyId) return payload.familyId;
+    }
+  } catch {
+    // Fall back to the route when the token is unavailable or cannot be decoded.
+  }
+
+  return window.location.pathname.split('/').filter(Boolean)[0] || 'default';
+}
+
+function getStorageKey(): string {
+  return `${STORAGE_KEY_PREFIX}:${getStorageScope()}`;
+}
+
+export function normalizeBottleUnit(value: unknown): BottleUnit | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.toUpperCase();
+  return normalized === 'ML' || normalized === 'OZ' ? normalized : null;
+}
+
+export function readCachedDefaultBottleUnit(): BottleUnit {
+  if (typeof window === 'undefined') return DEFAULT_BOTTLE_UNIT;
+
+  try {
+    return normalizeBottleUnit(window.localStorage.getItem(getStorageKey())) || DEFAULT_BOTTLE_UNIT;
+  } catch {
+    return DEFAULT_BOTTLE_UNIT;
+  }
+}
+
+export function cacheDefaultBottleUnit(value: unknown): BottleUnit | null {
+  const unit = normalizeBottleUnit(value);
+  if (!unit || typeof window === 'undefined') return unit;
+
+  try {
+    window.localStorage.setItem(getStorageKey(), unit);
+  } catch {
+    // Ignore storage errors; the server remains the source of truth.
+  }
+
+  return unit;
+}

--- a/tests/defaultBottleUnit.test.ts
+++ b/tests/defaultBottleUnit.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_BOTTLE_UNIT, normalizeBottleUnit } from '@/src/utils/defaultBottleUnit';
+
+describe('default bottle unit', () => {
+  it('normalizes persisted unit values case-insensitively', () => {
+    expect(normalizeBottleUnit('ml')).toBe('ML');
+    expect(normalizeBottleUnit('OZ')).toBe('OZ');
+  });
+
+  it('rejects unsupported values and keeps OZ as the fallback', () => {
+    expect(normalizeBottleUnit('G')).toBeNull();
+    expect(normalizeBottleUnit(null)).toBeNull();
+    expect(DEFAULT_BOTTLE_UNIT).toBe('OZ');
+  });
+});


### PR DESCRIPTION
## Summary

- Persist the configured bottle volume unit in a family-scoped PWA cache.
- Prevent settings responses and refetches from being served stale.
- Refresh the unit when the PWA resumes or regains focus.
- Keep feed, pump, timeline, and inventory adjustment controls synchronized.
- Add coverage for unit normalization and cache behavior.

Fixes #210

## Validation

- Targeted Vitest suites: 29 tests passed.
- `git diff --check`: passed.
- The full test suite still reports existing missing dependency failures for `csv-parse/sync` and `exif-reader`.
