### PR TITLE
fix: support grams (g) weight unit in MeasurementForm and GrowthChart

### DIFF
--- a/app/api/babies/[babyId]/report/[yearMonth]/route.ts
+++ b/app/api/babies/[babyId]/report/[yearMonth]/route.ts
@@ -244,7 +244,7 @@ async function handleGet(req: NextRequest, authContext: AuthResult): Promise<Nex
     if (type === 'weight') {
       if (displayWeightUnit === 'LB') return value / 0.453592;
       if (displayWeightUnit === 'OZ') return value / 0.0283495;
-      if (displayWeightUnit === 'G') return value * 1000;
+      // G (grams) auto-converts to kg for display in growth trends
       return value; // kg
     }
     // length / head — convert from cm to display unit
@@ -313,7 +313,10 @@ async function handleGet(req: NextRequest, authContext: AuthResult): Promise<Nex
     }
 
     // Convert measurement to display unit for consistency with the chart
-    const expectedUnit = cdcTable === 'weight' ? displayWeightUnit : displayHeightUnit;
+    // G (grams) auto-converts to kg for display in growth trends
+    const expectedUnit = cdcTable === 'weight'
+      ? (displayWeightUnit === 'G' ? 'KG' : displayWeightUnit)
+      : displayHeightUnit;
     const storedUnit = (measurement.unit || '').toUpperCase().trim();
     let displayValue = measurement.value;
     let displayUnit = measurement.unit;
@@ -410,7 +413,9 @@ async function handleGet(req: NextRequest, authContext: AuthResult): Promise<Nex
       }
       if (closest) {
         const storedUnit = (closest.unit || '').toUpperCase().trim();
-        const expectedDisplayUnit = cdcTable === 'weight' ? displayWeightUnit : displayHeightUnit;
+        const expectedDisplayUnit = cdcTable === 'weight'
+          ? (displayWeightUnit === 'G' ? 'KG' : displayWeightUnit)
+          : displayHeightUnit;
         if (storedUnit === expectedDisplayUnit || storedUnit === '') {
           point.measurement = closest.displayValue;
         } else {

--- a/src/components/Reports/GrowthChart.tsx
+++ b/src/components/Reports/GrowthChart.tsx
@@ -270,7 +270,9 @@ const getUnitLabel = (type: GrowthMeasurementType, settings: Settings | null): s
 
   switch (type) {
     case 'weight':
-      return settings.defaultWeightUnit === 'LB' ? 'lb' : 'kg';
+      if (settings.defaultWeightUnit === 'LB') return 'lb';
+      // G (grams) auto-converts to kg for display in growth trends
+      return 'kg';
     case 'length':
     case 'head_circumference':
       return settings.defaultHeightUnit === 'IN' ? 'in' : 'cm';
@@ -291,8 +293,11 @@ const getDisplayUnit = (type: GrowthMeasurementType, settings: Settings | null):
   }
 
   switch (type) {
-    case 'weight':
-      return settings.defaultWeightUnit || 'KG';
+    case 'weight': {
+      const unit = settings.defaultWeightUnit || 'KG';
+      // G (grams) auto-converts to kg for display in growth trends
+      return unit === 'G' ? 'KG' : unit;
+    }
     case 'length':
     case 'head_circumference':
       return settings.defaultHeightUnit || 'CM';
@@ -949,7 +954,7 @@ const GrowthChart: React.FC<GrowthChartProps> = ({ className }) => {
           <ResponsiveContainer width="100%" height={400}>
             <LineChart
               data={chartData}
-              margin={{ top: 20, right: 30, left: 2, bottom: 15 }}
+              margin={{ top: 20, right: 30, left: 15, bottom: 15 }}
             >
               <CartesianGrid strokeDasharray="3 3" className="growth-chart-grid" />
               <XAxis

--- a/src/components/forms/MeasurementForm/index.tsx
+++ b/src/components/forms/MeasurementForm/index.tsx
@@ -131,7 +131,7 @@ export default function MeasurementForm({
             const settings = data.data;
             setDefaultUnits({
               height: settings.defaultHeightUnit === 'IN' ? 'in' : 'cm',
-              weight: settings.defaultWeightUnit === 'KG' ? 'kg' : 'lb',
+              weight: settings.defaultWeightUnit === 'KG' ? 'kg' : settings.defaultWeightUnit === 'G' ? 'g' : 'lb',
               headCircumference: settings.defaultHeightUnit === 'IN' ? 'in' : 'cm', // Using height unit for head circumference
               temperature: settings.defaultTempUnit === 'F' ? '°F' : '°C',
             });
@@ -215,6 +215,8 @@ export default function MeasurementForm({
           case 'WEIGHT':
             if (activity.unit === 'kg') {
               updatedFormData.weight = { value: String(activity.value), unit: 'kg' };
+            } else if (activity.unit === 'g') {
+              updatedFormData.weight = { value: String(activity.value), unit: 'g' };
             } else {
               // Both 'lb' and legacy 'oz' use the lb/oz dual input
               const decimalLbs = activity.unit === 'oz' ? activity.value / 16 : activity.value;
@@ -755,6 +757,16 @@ export default function MeasurementForm({
                     className="px-2 py-1 h-9"
                   >
                     kg
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={formData.weight.unit === 'g' ? 'default' : 'outline'}
+                    onClick={() => handleUnitChange('weight', 'g')}
+                    disabled={loading}
+                    className="px-2 py-1 h-9"
+                  >
+                    g
                   </Button>
                 </div>
               </div>

--- a/tests/weight-unit-g-grams.test.ts
+++ b/tests/weight-unit-g-grams.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+
+// Test the conversion functions from GrowthChart.tsx
+// Import by re-deriving the logic (the functions are local to the component file,
+// so test the logic directly as pure functions)
+
+describe('Weight unit grams support', () => {
+  // Test that getUnitLabel logic handles 'G' correctly — auto-converts to kg
+  describe('getUnitLabel logic', () => {
+    function getUnitLabel(weightUnit: string | null): string {
+      if (!weightUnit) return 'kg';
+      if (weightUnit === 'LB') return 'lb';
+      // G (grams) auto-converts to kg for display in growth trends
+      return 'kg';
+    }
+
+    it('returns lb for LB setting', () => {
+      expect(getUnitLabel('LB')).toBe('lb');
+    });
+
+    it('returns kg for G setting (auto-converts grams to kg)', () => {
+      expect(getUnitLabel('G')).toBe('kg');
+    });
+
+    it('returns kg for KG setting', () => {
+      expect(getUnitLabel('KG')).toBe('kg');
+    });
+
+    it('returns kg for null/undefined setting', () => {
+      expect(getUnitLabel(null)).toBe('kg');
+    });
+  });
+
+  // Test formatWeightDisplay handles 'g' unit
+  describe('formatWeightDisplay with grams', () => {
+    function formatWeightDisplay(value: number, unit: string): string {
+      if (unit.toLowerCase() === 'lb') {
+        let lbs = Math.floor(value);
+        let oz = Math.round((value - lbs) * 16 * 10) / 10;
+        if (oz >= 16) { lbs += 1; oz -= 16; }
+        if (lbs === 0 && oz === 0) return `0 lbs`;
+        if (lbs === 0) return `${oz} oz`;
+        if (oz === 0) return `${lbs} lbs`;
+        return `${lbs} lb ${oz} oz`;
+      }
+      return `${value} ${unit}`;
+    }
+
+    it('displays grams value with g suffix', () => {
+      expect(formatWeightDisplay(3500, 'g')).toBe('3500 g');
+    });
+
+    it('displays kilograms value with kg suffix', () => {
+      expect(formatWeightDisplay(3.5, 'kg')).toBe('3.5 kg');
+    });
+
+    it('displays pounds in lb/oz format', () => {
+      expect(formatWeightDisplay(7.5, 'lb')).toBe('7 lb 8 oz');
+    });
+  });
+
+  // Test CDC conversion functions handle grams — G now auto-converts to kg display
+  describe('CDC conversion with grams', () => {
+    function convertToCdcUnit(value: number, unit: string): number {
+      const u = unit.toUpperCase().trim();
+      if (u === 'LB') return value * 0.453592;
+      if (u === 'OZ') return value * 0.0283495;
+      if (u === 'G') return value / 1000;
+      if (u === 'KG') return value;
+      return value;
+    }
+
+    function convertFromCdcToDisplayUnit(value: number, displayUnit: string): number {
+      const u = displayUnit.toUpperCase().trim();
+      if (u === 'LB') return value / 0.453592;
+      if (u === 'OZ') return value / 0.0283495;
+      // G (grams) auto-converts to kg for display in growth trends
+      return value;
+    }
+
+    it('converts grams to CDC kg correctly', () => {
+      expect(convertToCdcUnit(3500, 'g')).toBeCloseTo(3.5, 4);
+    });
+
+    it('converts CDC kg to kg display when setting is G (auto-convert)', () => {
+      expect(convertFromCdcToDisplayUnit(3.5, 'G')).toBeCloseTo(3.5, 4);
+    });
+
+    it('round-trips: 3010g → CDC → display = 3.010 kg', () => {
+      const cdc = convertToCdcUnit(3010, 'g');
+      const display = convertFromCdcToDisplayUnit(cdc, 'G');
+      expect(display).toBeCloseTo(3.01, 3);
+    });
+
+    it('round-trips: 3500g → CDC → display = 3.5 kg', () => {
+      const cdc = convertToCdcUnit(3500, 'g');
+      const display = convertFromCdcToDisplayUnit(cdc, 'G');
+      expect(display).toBeCloseTo(3.5, 3);
+    });
+  });
+
+  // Test getDisplayUnit logic — G maps to KG
+  describe('getDisplayUnit logic', () => {
+    function getDisplayUnit(weightUnit: string | null): string {
+      if (!weightUnit) return 'KG';
+      const unit = weightUnit || 'KG';
+      // G (grams) auto-converts to kg for display in growth trends
+      return unit === 'G' ? 'KG' : unit;
+    }
+
+    it('returns KG for G setting (auto-convert)', () => {
+      expect(getDisplayUnit('G')).toBe('KG');
+    });
+
+    it('returns KG for KG setting', () => {
+      expect(getDisplayUnit('KG')).toBe('KG');
+    });
+
+    it('returns LB for LB setting', () => {
+      expect(getDisplayUnit('LB')).toBe('LB');
+    });
+
+    it('returns KG for null/undefined setting', () => {
+      expect(getDisplayUnit(null)).toBe('KG');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #222 - Adds support for the grams (g) weight unit in the MeasurementForm component and GrowthChart visualization. Also includes tests for the new weight unit handling.