### PR TITLE
Add API-key hooks edit/delete activity endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ See [Initial Setup](documentation/Admin-Documentation/initial-setup.md) for deta
 | [Upgrades and Backups](documentation/Admin-Documentation/upgrades-and-backups.md) | Upgrade procedures, backup/restore for Docker and local |
 | [Push Notifications](documentation/Admin-Documentation/push-notifications.md) | VAPID keys, cron setup, per-user configuration |
 | [Webhook API](documentation/Admin-Documentation/webhook-api.md) | External integrations (Home Assistant, Grafana, NFC, etc.) |
+| [Sprout Track Fork Maintenance](documentation/Admin-Documentation/sprout-track-fork.md) | Local fork image build and upstream rebase workflow |
 | [API Logging](documentation/Admin-Documentation/api-logging.md) | Optional request/response logging |
 | [Admin Password Reset](documentation/Admin-Documentation/admin-password-reset.md) | Automatic reset when upgrading from older versions |
 

--- a/app/api/hooks/v1/babies/[babyId]/activities/[activityId]/route.ts
+++ b/app/api/hooks/v1/babies/[babyId]/activities/[activityId]/route.ts
@@ -1,0 +1,591 @@
+import { NextRequest } from 'next/server';
+import type { Prisma } from '@prisma/client';
+import prisma from '../../../../../../db';
+import { withApiKeyAuth, ApiKeyContext, validateBabyAccess } from '../../../../auth';
+import { checkRateLimit } from '../../../../rate-limiter';
+import { hookSuccess, hookError } from '../../../../response';
+
+const VALID_TYPES = ['sleep', 'feed', 'diaper', 'note', 'pump', 'play', 'bath', 'measurement', 'medicine', 'supplement'] as const;
+type ActivityType = typeof VALID_TYPES[number];
+
+type RouteContext = {
+  params: Promise<{ babyId: string; activityId: string }>;
+};
+
+type JsonObject = Record<string, unknown>;
+
+type MutationSummary = {
+  activityType: ActivityType;
+  id: string;
+  babyId: string;
+  time?: string;
+  status: 'updated' | 'deleted';
+  details?: JsonObject;
+};
+
+type FoundActivity = {
+  type: ActivityType;
+  id: string;
+  babyId: string;
+  time?: Date;
+};
+
+const TYPE_ALIASES: Record<string, ActivityType> = {
+  sleep: 'sleep',
+  feed: 'feed',
+  diaper: 'diaper',
+  note: 'note',
+  pump: 'pump',
+  play: 'play',
+  bath: 'bath',
+  measurement: 'measurement',
+  medicine: 'medicine',
+  supplement: 'supplement',
+};
+
+const TYPE_FIELDS: Record<ActivityType, readonly string[]> = {
+  sleep: ['type', 'sleepType', 'time', 'startTime', 'endTime', 'duration', 'location', 'quality'],
+  feed: ['type', 'feedType', 'time', 'startTime', 'endTime', 'duration', 'feedDuration', 'amount', 'unitAbbr', 'side', 'food', 'notes', 'bottleType', 'breastMilkAmount'],
+  diaper: ['type', 'diaperType', 'time', 'condition', 'color', 'blowout', 'creamApplied'],
+  note: ['type', 'time', 'content', 'category'],
+  pump: ['type', 'time', 'startTime', 'endTime', 'duration', 'leftAmount', 'rightAmount', 'totalAmount', 'unitAbbr', 'pumpAction', 'notes'],
+  play: ['type', 'time', 'startTime', 'duration', 'playType', 'notes', 'activities'],
+  bath: ['type', 'time', 'bathType', 'soapUsed', 'shampooUsed', 'notes'],
+  measurement: ['type', 'measurementType', 'time', 'date', 'value', 'unit', 'notes'],
+  medicine: ['type', 'medicineName', 'time', 'amount', 'doseAmount', 'unitAbbr', 'notes'],
+  supplement: ['type', 'supplementName', 'medicineName', 'time', 'amount', 'doseAmount', 'unitAbbr', 'notes'],
+};
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseActivityType(value: unknown): ActivityType | null {
+  if (typeof value !== 'string') return null;
+  return TYPE_ALIASES[value] ?? null;
+}
+
+function parseDate(value: unknown, field: string): { value?: Date; error?: string } {
+  if (value === undefined) return {};
+  if (typeof value !== 'string') return { error: `${field} must be an ISO 8601 string` };
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return { error: `${field} must be a valid ISO 8601 timestamp` };
+  return { value: date };
+}
+
+function parseNumber(value: unknown, field: string): { value?: number | null; error?: string } {
+  if (value === undefined) return {};
+  if (value === null) return { value: null };
+  const number = typeof value === 'number' ? value : typeof value === 'string' && value.trim() ? Number(value) : NaN;
+  if (!Number.isFinite(number)) return { error: `${field} must be a finite number` };
+  return { value: number };
+}
+
+function parseBoolean(value: unknown, field: string): { value?: boolean; error?: string } {
+  if (value === undefined) return {};
+  if (typeof value !== 'boolean') return { error: `${field} must be a boolean` };
+  return { value };
+}
+
+function parseString(value: unknown, field: string): { value?: string | null; error?: string } {
+  if (value === undefined) return {};
+  if (value === null) return { value: null };
+  if (typeof value !== 'string') return { error: `${field} must be a string` };
+  const trimmed = value.trim();
+  return { value: trimmed || null };
+}
+
+function rejectUnknownFields(type: ActivityType, body: JsonObject): string | null {
+  const allowed = new Set(TYPE_FIELDS[type]);
+  const forbidden = Object.keys(body).filter((key) => !allowed.has(key));
+  if (!forbidden.length) return null;
+  return `Unsupported field(s) for ${type}: ${forbidden.join(', ')}`;
+}
+
+function requireEnum<T extends string>(value: unknown, field: string, allowed: readonly T[]): { value?: T; error?: string } {
+  if (value === undefined) return {};
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    return { error: `${field} must be one of: ${allowed.join(', ')}` };
+  }
+  return { value: value as T };
+}
+
+function assignDate(target: JsonObject, body: JsonObject, sourceField: string, targetField: string): string | null {
+  const parsed = parseDate(body[sourceField], sourceField);
+  if (parsed.error) return parsed.error;
+  if (parsed.value) target[targetField] = parsed.value;
+  return null;
+}
+
+function assignNumber(target: JsonObject, body: JsonObject, sourceField: string, targetField = sourceField): string | null {
+  const parsed = parseNumber(body[sourceField], sourceField);
+  if (parsed.error) return parsed.error;
+  if (parsed.value !== undefined) target[targetField] = parsed.value;
+  return null;
+}
+
+function assignString(target: JsonObject, body: JsonObject, sourceField: string, targetField = sourceField): string | null {
+  const parsed = parseString(body[sourceField], sourceField);
+  if (parsed.error) return parsed.error;
+  if (parsed.value !== undefined) target[targetField] = parsed.value;
+  return null;
+}
+
+function assignBoolean(target: JsonObject, body: JsonObject, sourceField: string, targetField = sourceField): string | null {
+  const parsed = parseBoolean(body[sourceField], sourceField);
+  if (parsed.error) return parsed.error;
+  if (parsed.value !== undefined) target[targetField] = parsed.value;
+  return null;
+}
+
+function timeFrom(body: JsonObject, explicitField: string): { value?: Date; error?: string } {
+  if (body[explicitField] !== undefined) return parseDate(body[explicitField], explicitField);
+  return parseDate(body.time, 'time');
+}
+
+function ensureNonEmptyUpdate(data: JsonObject): string | null {
+  return Object.keys(data).length ? null : 'At least one mutable field is required';
+}
+
+function toIso(value: Date | null | undefined): string | undefined {
+  return value ? value.toISOString() : undefined;
+}
+
+function summary(
+  activityType: ActivityType,
+  id: string,
+  babyId: string,
+  status: 'updated' | 'deleted',
+  time?: Date | null,
+  details?: JsonObject
+): MutationSummary {
+  return {
+    activityType,
+    id,
+    babyId,
+    status,
+    ...(time ? { time: time.toISOString() } : {}),
+    ...(details ? { details } : {}),
+  };
+}
+
+function buildFeedData(body: JsonObject): { data?: Prisma.FeedLogUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const feedType = requireEnum(body.feedType, 'feedType', ['BREAST', 'BOTTLE', 'SOLIDS'] as const);
+  if (feedType.error) return { error: feedType.error };
+  if (feedType.value) data.type = feedType.value;
+  for (const field of ['time', 'startTime', 'endTime'] as const) {
+    const error = assignDate(data, body, field, field);
+    if (error) return { error };
+  }
+  const duration = parseNumber(body.duration ?? body.feedDuration, body.duration !== undefined ? 'duration' : 'feedDuration');
+  if (duration.error) return { error: duration.error };
+  if (duration.value !== undefined) data.feedDuration = duration.value === null ? null : Math.round(duration.value * 60);
+  for (const field of ['amount', 'breastMilkAmount'] as const) {
+    const error = assignNumber(data, body, field);
+    if (error) return { error };
+  }
+  for (const field of ['unitAbbr', 'side', 'food', 'notes', 'bottleType'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.FeedLogUpdateInput };
+}
+
+function buildDiaperData(body: JsonObject): { data?: Prisma.DiaperLogUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const diaperType = requireEnum(body.diaperType, 'diaperType', ['WET', 'DIRTY', 'BOTH'] as const);
+  if (diaperType.error) return { error: diaperType.error };
+  if (diaperType.value) data.type = diaperType.value;
+  const timeError = assignDate(data, body, 'time', 'time');
+  if (timeError) return { error: timeError };
+  for (const field of ['condition', 'color'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  for (const field of ['blowout', 'creamApplied'] as const) {
+    const error = assignBoolean(data, body, field);
+    if (error) return { error };
+  }
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.DiaperLogUpdateInput };
+}
+
+function buildSleepData(body: JsonObject): { data?: Prisma.SleepLogUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const sleepType = requireEnum(body.sleepType, 'sleepType', ['NAP', 'NIGHT_SLEEP'] as const);
+  if (sleepType.error) return { error: sleepType.error };
+  if (sleepType.value) data.type = sleepType.value;
+  const start = timeFrom(body, 'startTime');
+  if (start.error) return { error: start.error };
+  if (start.value) data.startTime = start.value;
+  const endError = assignDate(data, body, 'endTime', 'endTime');
+  if (endError) return { error: endError };
+  const durationError = assignNumber(data, body, 'duration');
+  if (durationError) return { error: durationError };
+  for (const field of ['location', 'quality'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.SleepLogUpdateInput };
+}
+
+function buildNoteData(body: JsonObject): { data?: Prisma.NoteUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const timeError = assignDate(data, body, 'time', 'time');
+  if (timeError) return { error: timeError };
+  for (const field of ['content', 'category'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.NoteUpdateInput };
+}
+
+function buildPumpData(body: JsonObject): { data?: Prisma.PumpLogUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const start = timeFrom(body, 'startTime');
+  if (start.error) return { error: start.error };
+  if (start.value) data.startTime = start.value;
+  const endError = assignDate(data, body, 'endTime', 'endTime');
+  if (endError) return { error: endError };
+  for (const field of ['duration', 'leftAmount', 'rightAmount', 'totalAmount'] as const) {
+    const error = assignNumber(data, body, field);
+    if (error) return { error };
+  }
+  for (const field of ['unitAbbr', 'notes'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  const pumpAction = requireEnum(body.pumpAction, 'pumpAction', ['STORED', 'FED', 'DISCARDED'] as const);
+  if (pumpAction.error) return { error: pumpAction.error };
+  if (pumpAction.value) data.pumpAction = pumpAction.value;
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.PumpLogUpdateInput };
+}
+
+function buildPlayData(body: JsonObject): { data?: Prisma.PlayLogUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const start = timeFrom(body, 'startTime');
+  if (start.error) return { error: start.error };
+  if (start.value) data.startTime = start.value;
+  const duration = parseNumber(body.duration, 'duration');
+  if (duration.error) return { error: duration.error };
+  if (duration.value !== undefined) {
+    data.duration = duration.value;
+    if (duration.value && data.startTime instanceof Date) {
+      data.endTime = new Date(data.startTime.getTime() + duration.value * 60000);
+    }
+  }
+  const playType = requireEnum(body.playType, 'playType', ['TUMMY_TIME', 'INDOOR_PLAY', 'OUTDOOR_PLAY', 'WALK', 'CUSTOM'] as const);
+  if (playType.error) return { error: playType.error };
+  if (playType.value) data.type = playType.value;
+  for (const field of ['notes', 'activities'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.PlayLogUpdateInput };
+}
+
+function buildBathData(body: JsonObject): { data?: Prisma.BathLogUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const timeError = assignDate(data, body, 'time', 'time');
+  if (timeError) return { error: timeError };
+  for (const field of ['bathType', 'notes'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  for (const field of ['soapUsed', 'shampooUsed'] as const) {
+    const error = assignBoolean(data, body, field);
+    if (error) return { error };
+  }
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.BathLogUpdateInput };
+}
+
+function buildMeasurementData(body: JsonObject): { data?: Prisma.MeasurementUpdateInput; error?: string } {
+  const data: JsonObject = {};
+  const measurementType = requireEnum(body.measurementType, 'measurementType', ['WEIGHT', 'HEIGHT', 'HEAD_CIRCUMFERENCE', 'TEMPERATURE'] as const);
+  if (measurementType.error) return { error: measurementType.error };
+  if (measurementType.value) data.type = measurementType.value;
+  const date = timeFrom(body, 'date');
+  if (date.error) return { error: date.error };
+  if (date.value) data.date = date.value;
+  const valueError = assignNumber(data, body, 'value');
+  if (valueError) return { error: valueError };
+  for (const field of ['unit', 'notes'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.MeasurementUpdateInput };
+}
+
+async function buildMedicineData(
+  body: JsonObject,
+  familyId: string,
+  isSupplement: boolean
+): Promise<{ data?: Prisma.MedicineLogUpdateInput; error?: string; status?: number }> {
+  const data: JsonObject = {};
+  const timeError = assignDate(data, body, 'time', 'time');
+  if (timeError) return { error: timeError };
+  const amount = parseNumber(body.amount ?? body.doseAmount, body.amount !== undefined ? 'amount' : 'doseAmount');
+  if (amount.error) return { error: amount.error };
+  if (amount.value !== undefined) data.doseAmount = amount.value ?? 0;
+  for (const field of ['unitAbbr', 'notes'] as const) {
+    const error = assignString(data, body, field);
+    if (error) return { error };
+  }
+
+  const nameField = isSupplement ? 'supplementName' : 'medicineName';
+  const providedName = body[nameField] ?? (isSupplement ? body.medicineName : undefined);
+  const parsedName = parseString(providedName, nameField);
+  if (parsedName.error) return { error: parsedName.error };
+  if (parsedName.value) {
+    const medicine = await prisma.medicine.findFirst({
+      where: { familyId, name: { equals: parsedName.value }, isSupplement, deletedAt: null },
+      select: { id: true, name: true },
+    });
+    if (!medicine) {
+      return {
+        error: `${isSupplement ? 'Supplement' : 'Medicine'} '${parsedName.value}' not found`,
+        status: 404,
+      };
+    }
+    data.medicine = { connect: { id: medicine.id } };
+  }
+
+  const empty = ensureNonEmptyUpdate(data);
+  return empty ? { error: empty } : { data: data as Prisma.MedicineLogUpdateInput };
+}
+
+async function findExistingActivity(type: ActivityType, activityId: string, babyId: string, familyId: string): Promise<FoundActivity | null> {
+  switch (type) {
+    case 'feed': {
+      const row = await prisma.feedLog.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, time: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.time } : null;
+    }
+    case 'diaper': {
+      const row = await prisma.diaperLog.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, time: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.time } : null;
+    }
+    case 'sleep': {
+      const row = await prisma.sleepLog.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, startTime: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.startTime } : null;
+    }
+    case 'note': {
+      const row = await prisma.note.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, time: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.time } : null;
+    }
+    case 'pump': {
+      const row = await prisma.pumpLog.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, startTime: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.startTime } : null;
+    }
+    case 'play': {
+      const row = await prisma.playLog.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, startTime: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.startTime } : null;
+    }
+    case 'bath': {
+      const row = await prisma.bathLog.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, time: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.time } : null;
+    }
+    case 'measurement': {
+      const row = await prisma.measurement.findFirst({ where: { id: activityId, babyId, familyId, deletedAt: null }, select: { id: true, babyId: true, date: true } });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.date } : null;
+    }
+    case 'medicine':
+    case 'supplement': {
+      const row = await prisma.medicineLog.findFirst({
+        where: { id: activityId, babyId, familyId, deletedAt: null, medicine: { isSupplement: type === 'supplement' } },
+        select: { id: true, babyId: true, time: true },
+      });
+      return row ? { type, id: row.id, babyId: row.babyId, time: row.time } : null;
+    }
+  }
+}
+
+async function findAnyExistingActivity(activityId: string, babyId: string, familyId: string): Promise<FoundActivity | null> {
+  for (const type of VALID_TYPES) {
+    const found = await findExistingActivity(type, activityId, babyId, familyId);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function updateActivity(type: ActivityType, activityId: string, babyId: string, familyId: string, body: JsonObject): Promise<{ result?: MutationSummary; error?: string; status?: number }> {
+  const existing = await findExistingActivity(type, activityId, babyId, familyId);
+  if (!existing) return { error: `${type} activity not found`, status: 404 };
+
+  switch (type) {
+    case 'feed': {
+      const built = buildFeedData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.feedLog.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.time, { type: row.type, amount: row.amount, unitAbbr: row.unitAbbr, notes: row.notes }) };
+    }
+    case 'diaper': {
+      const built = buildDiaperData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.diaperLog.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.time, { type: row.type, condition: row.condition, color: row.color, blowout: row.blowout, creamApplied: row.creamApplied }) };
+    }
+    case 'sleep': {
+      const built = buildSleepData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.sleepLog.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.startTime, { type: row.type, startTime: row.startTime.toISOString(), endTime: toIso(row.endTime), duration: row.duration, location: row.location, quality: row.quality }) };
+    }
+    case 'note': {
+      const built = buildNoteData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.note.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.time, { content: row.content, category: row.category }) };
+    }
+    case 'pump': {
+      const built = buildPumpData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.pumpLog.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.startTime, { startTime: row.startTime.toISOString(), endTime: toIso(row.endTime), duration: row.duration, totalAmount: row.totalAmount, unitAbbr: row.unitAbbr, pumpAction: row.pumpAction }) };
+    }
+    case 'play': {
+      const built = buildPlayData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.playLog.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.startTime, { type: row.type, startTime: row.startTime.toISOString(), endTime: toIso(row.endTime), duration: row.duration, notes: row.notes, activities: row.activities }) };
+    }
+    case 'bath': {
+      const built = buildBathData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.bathLog.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.time, { bathType: row.bathType, soapUsed: row.soapUsed, shampooUsed: row.shampooUsed, notes: row.notes }) };
+    }
+    case 'measurement': {
+      const built = buildMeasurementData(body);
+      if (built.error) return { error: built.error, status: 400 };
+      const row = await prisma.measurement.update({ where: { id: activityId }, data: built.data! });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.date, { type: row.type, value: row.value, unit: row.unit, notes: row.notes }) };
+    }
+    case 'medicine':
+    case 'supplement': {
+      const built = await buildMedicineData(body, familyId, type === 'supplement');
+      if (built.error) return { error: built.error, status: built.status ?? 400 };
+      const row = await prisma.medicineLog.update({
+        where: { id: activityId },
+        data: built.data!,
+        include: { medicine: { select: { name: true, isSupplement: true } } },
+      });
+      return { result: summary(type, row.id, row.babyId, 'updated', row.time, { medicineName: row.medicine.name, doseAmount: row.doseAmount, unitAbbr: row.unitAbbr, notes: row.notes }) };
+    }
+  }
+}
+
+async function deleteActivity(existing: FoundActivity): Promise<void> {
+  switch (existing.type) {
+    case 'feed':
+      await prisma.feedLog.delete({ where: { id: existing.id } });
+      return;
+    case 'diaper':
+      await prisma.diaperLog.delete({ where: { id: existing.id } });
+      return;
+    case 'sleep':
+      await prisma.sleepLog.delete({ where: { id: existing.id } });
+      return;
+    case 'note':
+      await prisma.note.delete({ where: { id: existing.id } });
+      return;
+    case 'pump':
+      await prisma.pumpLog.delete({ where: { id: existing.id } });
+      return;
+    case 'play':
+      await prisma.playLog.delete({ where: { id: existing.id } });
+      return;
+    case 'bath':
+      await prisma.bathLog.delete({ where: { id: existing.id } });
+      return;
+    case 'measurement':
+      await prisma.measurement.delete({ where: { id: existing.id } });
+      return;
+    case 'medicine':
+    case 'supplement':
+      await prisma.medicineLog.delete({ where: { id: existing.id } });
+      return;
+  }
+}
+
+async function readJsonBody(req: NextRequest): Promise<{ body?: JsonObject; error?: string }> {
+  try {
+    const value = await req.json();
+    if (!isJsonObject(value)) return { error: 'Request body must be a JSON object' };
+    return { body: value };
+  } catch {
+    return { error: 'Request body must be valid JSON' };
+  }
+}
+
+async function handlePut(req: NextRequest, ctx: ApiKeyContext, routeContext?: RouteContext) {
+  const rl = checkRateLimit(ctx.keyId, 'PUT');
+  if (!rl.allowed) return rl.response!;
+
+  const params = await routeContext?.params;
+  const babyId = params?.babyId;
+  const activityId = params?.activityId;
+  if (!babyId || !activityId) return hookError('INVALID_ROUTE', 'babyId and activityId are required', 400, rl.headers);
+
+  const access = await validateBabyAccess(babyId, ctx);
+  if (!access.valid) return access.error!;
+
+  const parsed = await readJsonBody(req);
+  if (parsed.error) return hookError('INVALID_JSON', parsed.error, 400, rl.headers);
+  const body = parsed.body!;
+  const type = parseActivityType(body.type);
+  if (!type) return hookError('INVALID_ACTIVITY_TYPE', `type is required and must be one of: ${VALID_TYPES.join(', ')}`, 400, rl.headers);
+
+  const fieldError = rejectUnknownFields(type, body);
+  if (fieldError) return hookError('INVALID_FIELD', fieldError, 400, rl.headers);
+
+  try {
+    const updated = await updateActivity(type, activityId, babyId, ctx.familyId, body);
+    if (updated.error) return hookError(updated.status === 404 ? 'ACTIVITY_NOT_FOUND' : 'INVALID_UPDATE', updated.error, updated.status ?? 400, rl.headers);
+    return hookSuccess(updated.result!, { familyId: ctx.familyId, babyId }, rl.headers);
+  } catch (error) {
+    console.error('Error updating activity via hooks API:', error);
+    return hookError('INTERNAL_ERROR', 'Failed to update activity', 500, rl.headers);
+  }
+}
+
+async function handleDelete(req: NextRequest, ctx: ApiKeyContext, routeContext?: RouteContext) {
+  const rl = checkRateLimit(ctx.keyId, 'DELETE');
+  if (!rl.allowed) return rl.response!;
+
+  const params = await routeContext?.params;
+  const babyId = params?.babyId;
+  const activityId = params?.activityId;
+  if (!babyId || !activityId) return hookError('INVALID_ROUTE', 'babyId and activityId are required', 400, rl.headers);
+
+  const access = await validateBabyAccess(babyId, ctx);
+  if (!access.valid) return access.error!;
+
+  try {
+    const url = new URL(req.url);
+    const requestedType = parseActivityType(url.searchParams.get('type'));
+    const existing = requestedType
+      ? await findExistingActivity(requestedType, activityId, babyId, ctx.familyId)
+      : await findAnyExistingActivity(activityId, babyId, ctx.familyId);
+
+    if (!existing) {
+      return hookError('ACTIVITY_NOT_FOUND', 'Activity not found', 404, rl.headers);
+    }
+
+    await deleteActivity(existing);
+    return hookSuccess(summary(existing.type, existing.id, existing.babyId, 'deleted', existing.time), { familyId: ctx.familyId, babyId }, rl.headers);
+  } catch (error) {
+    console.error('Error deleting activity via hooks API:', error);
+    return hookError('INTERNAL_ERROR', 'Failed to delete activity', 500, rl.headers);
+  }
+}
+
+export const PUT = withApiKeyAuth(handlePut, 'write');
+export const DELETE = withApiKeyAuth(handleDelete, 'write');

--- a/app/api/hooks/v1/rate-limiter.ts
+++ b/app/api/hooks/v1/rate-limiter.ts
@@ -19,7 +19,7 @@ setInterval(() => {
 
 export function checkRateLimit(
   keyId: string,
-  method: 'GET' | 'POST'
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE'
 ): { allowed: boolean; response?: NextResponse; headers: Record<string, string> } {
   const limit = method === 'GET' ? 60 : 30;
   const windowMs = 60_000;

--- a/documentation/Admin-Documentation/sprout-track-fork.md
+++ b/documentation/Admin-Documentation/sprout-track-fork.md
@@ -1,0 +1,31 @@
+# Sprout Track Fork Maintenance
+
+This fork patch is based on upstream tag `1.6.0` and is intentionally narrow:
+
+- `app/api/hooks/v1/babies/[babyId]/activities/[activityId]/route.ts` adds API-key `PUT` and `DELETE` support for the ten hooks activity types.
+- `app/api/hooks/v1/rate-limiter.ts` allows `PUT` and `DELETE` to use the existing write rate limit.
+- Webhook documentation describes edit/delete payloads and delete semantics.
+
+## Build a Local Image
+
+```bash
+docker build -t sprout-track:1.6.0-hooks-edit-delete .
+```
+
+Use the same environment variables, volumes, and database migration process as the upstream `1.6.0` deployment. No Prisma schema migration is required for this patch.
+
+## Rebase When Upstream Releases
+
+```bash
+git fetch upstream --tags
+git checkout upstream-v1.6.0-hooks-edit-delete
+git rebase NEW_UPSTREAM_TAG
+npm ci
+npm run prisma:generate
+npm run prisma:generate:log
+npx tsc --noEmit
+npm test
+docker build -t sprout-track:NEW_UPSTREAM_TAG-hooks-edit-delete .
+```
+
+During rebase, inspect conflicts in `app/api/hooks/v1/` and any classic log routes whose update/delete semantics changed upstream. Keep this fork additive where possible so it can be dropped if upstream accepts equivalent hooks edit/delete support.

--- a/documentation/Admin-Documentation/webhook-api.md
+++ b/documentation/Admin-Documentation/webhook-api.md
@@ -544,6 +544,40 @@ Optional fields: `duration` (minutes), `notes`, `activities` (sub-category strin
 
 ---
 
+### PUT /babies/:babyId/activities/:activityId
+
+Edit an existing activity record through API-key auth.
+
+`type` is required in the JSON body so the hooks route can validate fields against the correct activity model. Only fields valid for that activity type are accepted; `familyId`, `babyId`, and `caretakerId` cannot be reassigned through this endpoint.
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer st_live_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"feed","amount":3,"unitAbbr":"OZ","notes":"Corrected amount"}' \
+  http://localhost:3000/api/hooks/v1/babies/BABY_ID/activities/ACTIVITY_ID
+```
+
+**Supported types:** `feed`, `diaper`, `sleep`, `note`, `pump`, `play`, `bath`, `measurement`, `medicine`, and `supplement`.
+
+The response includes `activityType`, `id`, `babyId`, `time` when applicable, `status: "updated"`, and type-specific confirmation details.
+
+### DELETE /babies/:babyId/activities/:activityId
+
+Delete an existing activity record through API-key auth.
+
+```bash
+curl -s -X DELETE \
+  -H "Authorization: Bearer st_live_YOUR_KEY" \
+  http://localhost:3000/api/hooks/v1/babies/BABY_ID/activities/ACTIVITY_ID
+```
+
+The hooks delete endpoint matches the current classic UI log behavior for these activity types: after confirming the row belongs to the API key's family and route baby, it hard-deletes the activity row. Add `?type=feed` if you already know the activity type and want to avoid type probing.
+
+The response includes `activityType`, `id`, `babyId`, `time` when applicable, and `status: "deleted"`.
+
+---
+
 ### GET /babies/:babyId/measurements/latest
 
 Returns the most recent measurement of each type.

--- a/documentation/Architecture-Documentation/APIDesignPatterns.md
+++ b/documentation/Architecture-Documentation/APIDesignPatterns.md
@@ -201,6 +201,8 @@ External integrations use a separate API surface at `app/api/hooks/v1/`:
 |----------|---------|
 | `GET /api/hooks/v1/babies/` | List babies |
 | `GET /api/hooks/v1/babies/[babyId]/activities/` | Recent activities |
+| `PUT /api/hooks/v1/babies/[babyId]/activities/[activityId]/` | Edit an existing activity |
+| `DELETE /api/hooks/v1/babies/[babyId]/activities/[activityId]/` | Delete an existing activity |
 | `GET /api/hooks/v1/babies/[babyId]/measurements/latest/` | Latest measurements |
 | `GET /api/hooks/v1/babies/[babyId]/status/` | Baby status summary |
 | `GET /api/hooks/v1/babies/[babyId]/reference/` | Reference data (valid enum values for activity fields) |

--- a/documentation/Implementation/sprout-track-ha-api-design.md
+++ b/documentation/Implementation/sprout-track-ha-api-design.md
@@ -559,23 +559,25 @@ X-RateLimit-Reset: 1709985600
 
 ---
 
-## What's Deferred (v2 Considerations)
+## Mutation Endpoints
 
 ### PUT — Editing Existing Records
-
-You mentioned this and I think you're right to defer it. The main use case would be ending an active sleep session or updating a feed amount, but the `action: "end"` pattern on POST handles the sleep case already. A true PUT would need record IDs, partial update semantics, and conflict resolution — more complexity than v1 warrants.
-
-If you do add it later, it would look like:
 
 ```
 PUT /api/hooks/v1/babies/:babyId/activities/:activityId
 ```
 
-With a body containing only the fields to update. The `activityType` would be inferred from the record.
+The body must include `type` plus the fields to update. The route accepts the same ten hooks activity types as POST and rejects fields that do not belong to the declared type. It does not allow family, baby, caretaker, or relation reassignment except resolving medicine/supplement names to an existing family-owned `Medicine` row.
 
 ### DELETE — Removing Records
 
-Similar reasoning. Logging errors happen, but they can be fixed in the Sprout Track UI. Exposing delete via API adds risk without much HA-specific value.
+```
+DELETE /api/hooks/v1/babies/:babyId/activities/:activityId
+```
+
+The route verifies API-key write scope, baby access, family ownership, and `deletedAt: null` before deleting. Delete semantics intentionally match the classic UI routes for these ten activity logs: the row is hard-deleted after access checks. A `type` query parameter is optional; when omitted, the route probes the supported activity tables by id.
+
+## What's Deferred (v2 Considerations)
 
 ### Outgoing Webhooks (Sprout Track → External Services)
 
@@ -627,3 +629,5 @@ Consider a `/api/docs` or `/integrations/home-assistant` page that:
 | GET | `/api/hooks/v1/babies/:babyId/activities` | read | Recent activity log (filterable) |
 | GET | `/api/hooks/v1/babies/:babyId/measurements/latest` | read | Latest measurements by type |
 | POST | `/api/hooks/v1/babies/:babyId/activities` | write | Log a new activity |
+| PUT | `/api/hooks/v1/babies/:babyId/activities/:activityId` | write | Edit an existing activity |
+| DELETE | `/api/hooks/v1/babies/:babyId/activities/:activityId` | write | Delete an existing activity |

--- a/tests/hooksActivityMutationRoute.test.ts
+++ b/tests/hooksActivityMutationRoute.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DELETE, PUT } from '../app/api/hooks/v1/babies/[babyId]/activities/[activityId]/route';
+
+const mocks = vi.hoisted(() => {
+  const delegate = () => ({
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  });
+
+  return {
+    prisma: {
+      apiKey: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+      baby: {
+        findFirst: vi.fn(),
+      },
+      medicine: {
+        findFirst: vi.fn(),
+      },
+      sleepLog: delegate(),
+      feedLog: delegate(),
+      diaperLog: delegate(),
+      note: delegate(),
+      pumpLog: delegate(),
+      playLog: delegate(),
+      bathLog: delegate(),
+      measurement: delegate(),
+      medicineLog: delegate(),
+    },
+  };
+});
+
+vi.mock('../app/api/db', () => ({
+  default: mocks.prisma,
+}));
+
+const routeContext = {
+  params: Promise.resolve({ babyId: 'baby-1', activityId: 'activity-1' }),
+};
+
+function request(method: 'PUT' | 'DELETE', body?: unknown, query = '') {
+  return new Request(`http://localhost/api/hooks/v1/babies/baby-1/activities/activity-1${query}`, {
+    method,
+    headers: {
+      authorization: 'Bearer st_live_test',
+      ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+async function json(response: Response) {
+  return response.json() as Promise<Record<string, any>>;
+}
+
+function resetDelegates() {
+  for (const delegate of [
+    mocks.prisma.sleepLog,
+    mocks.prisma.feedLog,
+    mocks.prisma.diaperLog,
+    mocks.prisma.note,
+    mocks.prisma.pumpLog,
+    mocks.prisma.playLog,
+    mocks.prisma.bathLog,
+    mocks.prisma.measurement,
+    mocks.prisma.medicineLog,
+  ]) {
+    delegate.findFirst.mockReset();
+    delegate.update.mockReset();
+    delegate.delete.mockReset();
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetDelegates();
+  mocks.prisma.apiKey.findUnique.mockResolvedValue({
+    id: `key-${crypto.randomUUID()}`,
+    familyId: 'family-1',
+    babyId: null,
+    scopes: JSON.stringify(['read', 'write']),
+    revoked: false,
+    expiresAt: null,
+  });
+  mocks.prisma.apiKey.update.mockResolvedValue({});
+  mocks.prisma.baby.findFirst.mockResolvedValue({ id: 'baby-1', familyId: 'family-1' });
+  mocks.prisma.medicine.findFirst.mockResolvedValue({ id: 'medicine-1', name: 'Vitamin D' });
+});
+
+describe('hooks activity mutation route', () => {
+  it.each([
+    ['feed', mocks.prisma.feedLog, { type: 'feed', notes: 'corrected' }, { id: 'activity-1', babyId: 'baby-1', time: new Date('2026-07-18T10:00:00Z'), type: 'BOTTLE', amount: 2, unitAbbr: 'OZ', notes: 'corrected' }],
+    ['diaper', mocks.prisma.diaperLog, { type: 'diaper', diaperType: 'WET' }, { id: 'activity-1', babyId: 'baby-1', time: new Date('2026-07-18T10:00:00Z'), type: 'WET', condition: null, color: null, blowout: false, creamApplied: false }],
+    ['sleep', mocks.prisma.sleepLog, { type: 'sleep', sleepType: 'NAP' }, { id: 'activity-1', babyId: 'baby-1', startTime: new Date('2026-07-18T10:00:00Z'), endTime: null, duration: 30, type: 'NAP', location: null, quality: null }],
+    ['note', mocks.prisma.note, { type: 'note', content: 'updated note' }, { id: 'activity-1', babyId: 'baby-1', time: new Date('2026-07-18T10:00:00Z'), content: 'updated note', category: null }],
+    ['pump', mocks.prisma.pumpLog, { type: 'pump', totalAmount: 3 }, { id: 'activity-1', babyId: 'baby-1', startTime: new Date('2026-07-18T10:00:00Z'), endTime: null, duration: 15, totalAmount: 3, unitAbbr: 'OZ', pumpAction: 'STORED' }],
+    ['play', mocks.prisma.playLog, { type: 'play', playType: 'TUMMY_TIME' }, { id: 'activity-1', babyId: 'baby-1', startTime: new Date('2026-07-18T10:00:00Z'), endTime: null, duration: 10, type: 'TUMMY_TIME', notes: null, activities: null }],
+    ['bath', mocks.prisma.bathLog, { type: 'bath', soapUsed: false }, { id: 'activity-1', babyId: 'baby-1', time: new Date('2026-07-18T10:00:00Z'), bathType: null, soapUsed: false, shampooUsed: true, notes: null }],
+    ['measurement', mocks.prisma.measurement, { type: 'measurement', value: 12.5 }, { id: 'activity-1', babyId: 'baby-1', date: new Date('2026-07-18T10:00:00Z'), type: 'WEIGHT', value: 12.5, unit: 'LB', notes: null }],
+    ['medicine', mocks.prisma.medicineLog, { type: 'medicine', medicineName: 'Vitamin D' }, { id: 'activity-1', babyId: 'baby-1', time: new Date('2026-07-18T10:00:00Z'), medicine: { name: 'Vitamin D' }, doseAmount: 1, unitAbbr: 'ML', notes: null }],
+    ['supplement', mocks.prisma.medicineLog, { type: 'supplement', supplementName: 'Vitamin D' }, { id: 'activity-1', babyId: 'baby-1', time: new Date('2026-07-18T10:00:00Z'), medicine: { name: 'Vitamin D' }, doseAmount: 1, unitAbbr: 'ML', notes: null }],
+  ])('updates %s activities through API-key auth', async (type, delegate, body, row) => {
+    const existing = row as Record<string, unknown>;
+    delegate.findFirst.mockResolvedValue({ id: 'activity-1', babyId: 'baby-1', time: existing.time, startTime: existing.startTime, date: existing.date });
+    delegate.update.mockResolvedValue(row);
+
+    const response = await PUT(request('PUT', body) as any, routeContext);
+    const payload = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.data).toMatchObject({ activityType: type, id: 'activity-1', babyId: 'baby-1', status: 'updated' });
+    expect(delegate.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ id: 'activity-1', babyId: 'baby-1', familyId: 'family-1', deletedAt: null }),
+    }));
+    expect(delegate.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'activity-1' } }));
+  });
+
+  it('rejects fields that do not belong to the requested activity type', async () => {
+    const response = await PUT(request('PUT', { type: 'diaper', medicineName: 'Vitamin D' }) as any, routeContext);
+    const payload = await json(response);
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe('INVALID_FIELD');
+    expect(mocks.prisma.diaperLog.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects API keys without write scope before touching activity rows', async () => {
+    mocks.prisma.apiKey.findUnique.mockResolvedValue({
+      id: 'read-key',
+      familyId: 'family-1',
+      babyId: null,
+      scopes: JSON.stringify(['read']),
+      revoked: false,
+      expiresAt: null,
+    });
+
+    const response = await PUT(request('PUT', { type: 'feed', notes: 'blocked' }) as any, routeContext);
+    const payload = await json(response);
+
+    expect(response.status).toBe(403);
+    expect(payload.error.code).toBe('INSUFFICIENT_SCOPE');
+    expect(mocks.prisma.feedLog.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('deletes the located activity when type is omitted', async () => {
+    mocks.prisma.feedLog.findFirst.mockResolvedValue({
+      id: 'activity-1',
+      babyId: 'baby-1',
+      time: new Date('2026-07-18T10:00:00Z'),
+    });
+    mocks.prisma.feedLog.delete.mockResolvedValue({});
+
+    const response = await DELETE(request('DELETE') as any, routeContext);
+    const payload = await json(response);
+
+    expect(response.status).toBe(200);
+    expect(payload.data).toMatchObject({ activityType: 'feed', id: 'activity-1', status: 'deleted' });
+    expect(mocks.prisma.feedLog.delete).toHaveBeenCalledWith({ where: { id: 'activity-1' } });
+    expect(mocks.prisma.diaperLog.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns not found instead of deleting an already missing activity', async () => {
+    const response = await DELETE(request('DELETE') as any, routeContext);
+    const payload = await json(response);
+
+    expect(response.status).toBe(404);
+    expect(payload.error.code).toBe('ACTIVITY_NOT_FOUND');
+    expect(mocks.prisma.feedLog.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `PUT /api/hooks/v1/babies/{babyId}/activities/{activityId}` with per-type validation for all 10 hooks activity types
- add `DELETE /api/hooks/v1/babies/{babyId}/activities/{activityId}` with API-key write auth and family/baby scoping
- document delete semantics, local fork image build, and upstream rebase workflow

## Validation
- `npm run prisma:generate`
- `npm run prisma:generate:log`
- `npx tsc --noEmit`
- `npm test`
- `DATABASE_URL="file:./dev.db" LOG_DATABASE_URL="file:./logs.db" npm run build`

## Notes
- Based on upstream tag `1.6.0` per LA-43 fork-maintenance scope.
- `npm run lint` currently fails before linting because `next lint` is treated as an invalid project directory by this Next.js version.
- Local Docker image build could not be run because the Docker daemon is not available at `~/.docker/run/docker.sock`.
