### PR TITLE
fix(breastfeed): track per-side timing, pauses, and correct start/end spans

### DIFF
--- a/app/api/utils/activeBreastFeed.ts
+++ b/app/api/utils/activeBreastFeed.ts
@@ -2,25 +2,13 @@ import { randomUUID } from 'crypto';
 import { ActiveBreastFeed, BreastSide } from '@prisma/client';
 import prisma from '../db';
 import { notifyActivityCreated, resetTimerNotificationState } from '@/src/lib/notifications/activityHook';
-
-/**
- * Shared active breastfeed session logic used by both the internal
- * /api/active-breastfeed route (JWT auth) and the external hooks API
- * (/api/hooks/v1, API-key auth) so timer behavior is identical
- * regardless of which surface starts, updates, or ends a session.
- */
+import { layoutBreastFeedSession } from '@/src/utils/feedSessionLayout';
+import { applySessionAction as pureApply, ActiveBreastFeedState } from '@/src/utils/feedSessionActions';
 
 export type SessionUpdateAction = 'switch' | 'pause' | 'resume' | 'swap';
+export type SessionActionUpdate = ReturnType<typeof pureApply> extends infer R ? R : never;
 
 export const SESSION_UPDATE_ACTIONS: SessionUpdateAction[] = ['switch', 'pause', 'resume', 'swap'];
-
-/** Seconds accrued on the currently active side since it started timing (0 when paused). */
-function elapsedSeconds(session: ActiveBreastFeed, now: Date): number {
-  if (session.currentSideStartTime && !session.isPaused) {
-    return Math.floor((now.getTime() - session.currentSideStartTime.getTime()) / 1000);
-  }
-  return 0;
-}
 
 export interface StartSessionParams {
   babyId: string;
@@ -29,11 +17,6 @@ export interface StartSessionParams {
   caretakerId?: string | null;
 }
 
-/**
- * Creates a new active session. Callers should check for an existing session
- * first; a concurrent start still races on the babyId unique constraint, so
- * catch Prisma P2002 and treat it as "already active".
- */
 export async function startBreastfeedSession({ babyId, side, familyId, caretakerId }: StartSessionParams): Promise<ActiveBreastFeed> {
   const now = new Date();
   return prisma.activeBreastFeed.create({
@@ -43,6 +26,9 @@ export async function startBreastfeedSession({ babyId, side, familyId, caretaker
       isPaused: false,
       leftDuration: 0,
       rightDuration: 0,
+      pauseDuration: 0,
+      pausedAt: null,
+      firstSide: side,
       currentSideStartTime: now,
       sessionStartTime: now,
       familyId,
@@ -51,66 +37,33 @@ export async function startBreastfeedSession({ babyId, side, familyId, caretaker
   });
 }
 
-/**
- * Applies a timer action to a session and returns the updated record.
- * - switch: accumulate time on current side, start timing the other side
- * - pause: accumulate time on current side, stop timing
- * - resume: start timing again (optionally on a given side)
- * - swap: reassign all accrued time to the opposite side (corrects starting
- *   the timer on the wrong side); running/paused state is preserved
- * Returns null for an unknown action.
- */
+export function applySessionAction(
+  session: ActiveBreastFeed,
+  action: SessionUpdateAction,
+  now: Date,
+  resumeSide?: BreastSide
+) {
+  const state: ActiveBreastFeedState = {
+    activeSide: session.activeSide,
+    isPaused: session.isPaused,
+    leftDuration: session.leftDuration,
+    rightDuration: session.rightDuration,
+    pauseDuration: session.pauseDuration,
+    pausedAt: session.pausedAt,
+    firstSide: session.firstSide,
+    currentSideStartTime: session.currentSideStartTime,
+  };
+  return pureApply(state, action, now, resumeSide);
+}
+
 export async function updateBreastfeedSession(
   session: ActiveBreastFeed,
   action: SessionUpdateAction,
   side?: BreastSide
 ): Promise<ActiveBreastFeed | null> {
   const now = new Date();
-  const elapsed = elapsedSeconds(session, now);
-
-  // Durations with the in-flight elapsed time folded in
-  const accruedLeft = session.activeSide === 'LEFT' ? session.leftDuration + elapsed : session.leftDuration;
-  const accruedRight = session.activeSide === 'RIGHT' ? session.rightDuration + elapsed : session.rightDuration;
-  const otherSide = session.activeSide === 'LEFT' ? 'RIGHT' : 'LEFT';
-
-  let updateData: any;
-
-  switch (action) {
-    case 'switch':
-      updateData = {
-        activeSide: otherSide,
-        leftDuration: accruedLeft,
-        rightDuration: accruedRight,
-        currentSideStartTime: now,
-        isPaused: false,
-      };
-      break;
-    case 'pause':
-      updateData = {
-        leftDuration: accruedLeft,
-        rightDuration: accruedRight,
-        currentSideStartTime: null,
-        isPaused: true,
-      };
-      break;
-    case 'resume':
-      updateData = {
-        activeSide: side || session.activeSide,
-        currentSideStartTime: now,
-        isPaused: false,
-      };
-      break;
-    case 'swap':
-      updateData = {
-        activeSide: otherSide,
-        leftDuration: accruedRight,
-        rightDuration: accruedLeft,
-        ...(session.isPaused ? {} : { currentSideStartTime: now }),
-      };
-      break;
-    default:
-      return null;
-  }
+  const updateData = applySessionAction(session, action, now, side);
+  if (!updateData) return null;
 
   return prisma.activeBreastFeed.update({
     where: { id: session.id },
@@ -122,7 +75,6 @@ export interface EndSessionOptions {
   familyId: string;
   caretakerId?: string | null;
   accountId?: string | null;
-  /** Optional duration overrides (seconds), e.g. from form adjustments */
   leftDuration?: number;
   rightDuration?: number;
 }
@@ -133,15 +85,17 @@ export interface EndSessionResult {
   rightDuration: number;
 }
 
-/**
- * Finalizes a session: creates one FeedLog per side with accrued time
- * (linked by a shared sessionId), deletes the session, and fires the same
- * notifications as the in-app end-feed flow.
- */
 export async function endBreastfeedSession(session: ActiveBreastFeed, opts: EndSessionOptions): Promise<EndSessionResult> {
   const now = new Date();
 
-  const elapsed = elapsedSeconds(session, now);
+  const elapsed = (session.currentSideStartTime && !session.isPaused)
+    ? Math.floor((now.getTime() - session.currentSideStartTime.getTime()) / 1000)
+    : 0;
+
+  const trailingPause = session.isPaused && session.pausedAt
+    ? Math.floor((now.getTime() - session.pausedAt.getTime()) / 1000)
+    : 0;
+  const finalPauseDuration = session.pauseDuration + trailingPause;
 
   const finalLeftDuration = session.activeSide === 'LEFT'
     ? session.leftDuration + elapsed
@@ -153,54 +107,39 @@ export async function endBreastfeedSession(session: ActiveBreastFeed, opts: EndS
   const leftDur = opts.leftDuration !== undefined ? opts.leftDuration : finalLeftDuration;
   const rightDur = opts.rightDuration !== undefined ? opts.rightDuration : finalRightDuration;
 
-  // Create FeedLog records for each side that has duration
-  // Last-fed side gets a slightly later startTime so it sorts first in lists
-  const baseStartTime = session.sessionStartTime;
-  const lastSideStartTime = new Date(baseStartTime.getTime() + 10);
-  // Both rows share a sessionId so they always count as one nursing session
+  const firstSide: BreastSide | null = session.firstSide ?? session.activeSide;
+  const blocks = layoutBreastFeedSession({
+    sessionStartTime: session.sessionStartTime,
+    firstSide,
+    leftDuration: leftDur,
+    rightDuration: rightDur,
+    pauseDuration: finalPauseDuration,
+  });
+
   const sessionId = randomUUID();
-  const feedLogs = [];
+  const feedLogs: { id: string; side: BreastSide | null; feedDuration: number | null }[] = [];
 
-  if (leftDur > 0) {
-    const leftLog = await prisma.feedLog.create({
+  for (const block of blocks) {
+    const log = await prisma.feedLog.create({
       data: {
         babyId: session.babyId,
         time: now,
         type: 'BREAST',
-        side: 'LEFT',
-        startTime: session.activeSide === 'LEFT' ? lastSideStartTime : baseStartTime,
-        endTime: now,
-        feedDuration: leftDur,
+        side: block.side,
+        startTime: block.startTime,
+        endTime: block.endTime,
+        feedDuration: block.duration,
+        pauseDuration: finalPauseDuration,
         sessionId,
         caretakerId: opts.caretakerId,
         familyId: opts.familyId,
       },
     });
-    feedLogs.push(leftLog);
+    feedLogs.push(log);
   }
 
-  if (rightDur > 0) {
-    const rightLog = await prisma.feedLog.create({
-      data: {
-        babyId: session.babyId,
-        time: now,
-        type: 'BREAST',
-        side: 'RIGHT',
-        startTime: session.activeSide === 'RIGHT' ? lastSideStartTime : baseStartTime,
-        endTime: now,
-        feedDuration: rightDur,
-        sessionId,
-        caretakerId: opts.caretakerId,
-        familyId: opts.familyId,
-      },
-    });
-    feedLogs.push(rightLog);
-  }
-
-  // Delete the active session
   await prisma.activeBreastFeed.delete({ where: { id: session.id } });
 
-  // Notify subscribers about completed breastfeed and reset feed timer (non-blocking)
   notifyActivityCreated(session.babyId, 'feed', { accountId: opts.accountId, caretakerId: opts.caretakerId }, { type: 'BREAST' }).catch(console.error);
   resetTimerNotificationState(session.babyId, 'feed').catch(console.error);
 

--- a/app/api/utils/activeBreastFeed.ts
+++ b/app/api/utils/activeBreastFeed.ts
@@ -6,7 +6,6 @@ import { layoutBreastFeedSession } from '@/src/utils/feedSessionLayout';
 import { applySessionAction as pureApply, ActiveBreastFeedState } from '@/src/utils/feedSessionActions';
 
 export type SessionUpdateAction = 'switch' | 'pause' | 'resume' | 'swap';
-export type SessionActionUpdate = ReturnType<typeof pureApply> extends infer R ? R : never;
 
 export const SESSION_UPDATE_ACTIONS: SessionUpdateAction[] = ['switch', 'pause', 'resume', 'swap'];
 
@@ -107,7 +106,7 @@ export async function endBreastfeedSession(session: ActiveBreastFeed, opts: EndS
   const leftDur = opts.leftDuration !== undefined ? opts.leftDuration : finalLeftDuration;
   const rightDur = opts.rightDuration !== undefined ? opts.rightDuration : finalRightDuration;
 
-  const firstSide: BreastSide | null = session.firstSide ?? session.activeSide;
+  const firstSide: BreastSide | null = session.firstSide ?? (session.activeSide === 'LEFT' ? 'RIGHT' : 'LEFT');
   const blocks = layoutBreastFeedSession({
     sessionStartTime: session.sessionStartTime,
     firstSide,

--- a/prisma/migrations/20260720120000_add_breastfeed_pause_tracking/migration.sql
+++ b/prisma/migrations/20260720120000_add_breastfeed_pause_tracking/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "ActiveBreastFeed" ADD COLUMN "pauseDuration" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "ActiveBreastFeed" ADD COLUMN "pausedAt" DATETIME;
+
+-- AlterTable
+ALTER TABLE "ActiveBreastFeed" ADD COLUMN "firstSide" TEXT;
+
+-- AlterTable
+ALTER TABLE "FeedLog" ADD COLUMN "pauseDuration" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -389,6 +389,7 @@ model FeedLog {
   startTime    DateTime? // Used for breast feeding duration tracking
   endTime      DateTime? // Used for breast feeding duration tracking
   feedDuration Int? // Duration in seconds, useful for tracking actual feeding time
+  pauseDuration Int? // Total session pause in seconds (same value on all rows of a breastfeed session; null on non-breast rows and legacy rows)
   type         FeedType
   amount       Float? // Amount in specified unit
   unit         Unit?       @relation(fields: [unitAbbr], references: [unitAbbr])
@@ -1498,6 +1499,9 @@ model ActiveBreastFeed {
   isPaused             Boolean     @default(false)
   leftDuration         Int         @default(0) // Accumulated seconds for left side
   rightDuration        Int         @default(0) // Accumulated seconds for right side
+  pauseDuration        Int         @default(0) // Accumulated seconds paused within the session
+  pausedAt             DateTime?               // When the session was last paused (null when not paused)
+  firstSide            BreastSide?             // Side used first in the session (for ordering consolidated rows); null on legacy rows
   currentSideStartTime DateTime? // When current side started timing (null when paused)
   sessionStartTime     DateTime // When the overall session began
   createdAt            DateTime    @default(now())

--- a/src/components/Timeline/utils.tsx
+++ b/src/components/Timeline/utils.tsx
@@ -392,6 +392,16 @@ export const getActivityDetails = (activity: ActivityType, settings: Settings | 
         } else if (activity.amount) {
           details.push({ label: t('Duration'), value: `${activity.amount} ${t('minutes')}` });
         }
+
+        if ((activity as any).pauseDuration && (activity as any).pauseDuration > 0) {
+          const p = (activity as any).pauseDuration as number;
+          const pm = Math.floor(p / 60);
+          const ps = p % 60;
+          details.push({
+            label: t('Pause'),
+            value: ps > 0 ? `${pm} ${t('min')} ${ps} ${t('sec')}` : `${pm} ${t('minutes')}`
+          });
+        }
       }
 
       // Show food for solids
@@ -840,8 +850,16 @@ export const getActivityDescription = (activity: ActivityType, settings: Setting
         } else if (activity.amount) {
           duration = `${activity.amount} ${t('min')}`;
         }
+
+        let pause = '';
+        if ((activity as any).pauseDuration && (activity as any).pauseDuration > 0) {
+          const p = (activity as any).pauseDuration as number;
+          const pm = Math.floor(p / 60);
+          const ps = p % 60;
+          pause = ps > 0 ? `${t('Pause')}: ${pm}${t('min')} ${ps}${t('sec')}` : `${t('Pause')}: ${pm} ${t('min')}`;
+        }
         
-        details = [side, duration].filter(Boolean).join(' • ');
+        details = [side, duration, pause].filter(Boolean).join(' • ');
       } else if (activity.type === 'BOTTLE') {
         // Use unitAbbr instead of hardcoded 'oz'
         const unit = ((activity as any).unitAbbr || 'oz').toLowerCase();

--- a/src/utils/feedSessionActions.ts
+++ b/src/utils/feedSessionActions.ts
@@ -1,0 +1,87 @@
+export type BreastSide = 'LEFT' | 'RIGHT';
+
+export interface ActiveBreastFeedState {
+  activeSide: BreastSide;
+  isPaused: boolean;
+  leftDuration: number;
+  rightDuration: number;
+  pauseDuration: number;
+  pausedAt: Date | null;
+  firstSide: BreastSide | null;
+  currentSideStartTime: Date | null;
+}
+
+export type SessionUpdateAction = 'switch' | 'pause' | 'resume' | 'swap';
+
+export interface SessionActionUpdate {
+  activeSide?: BreastSide;
+  isPaused?: boolean;
+  leftDuration?: number;
+  rightDuration?: number;
+  pauseDuration?: number;
+  pausedAt?: Date | null;
+  currentSideStartTime?: Date | null;
+  firstSide?: BreastSide | null;
+}
+
+function elapsedSeconds(state: ActiveBreastFeedState, now: Date): number {
+  if (state.currentSideStartTime && !state.isPaused) {
+    return Math.floor((now.getTime() - state.currentSideStartTime.getTime()) / 1000);
+  }
+  return 0;
+}
+
+export function applySessionAction(
+  state: ActiveBreastFeedState,
+  action: SessionUpdateAction,
+  now: Date,
+  resumeSide?: BreastSide
+): SessionActionUpdate | null {
+  const elapsed = elapsedSeconds(state, now);
+  const accruedLeft = state.activeSide === 'LEFT' ? state.leftDuration + elapsed : state.leftDuration;
+  const accruedRight = state.activeSide === 'RIGHT' ? state.rightDuration + elapsed : state.rightDuration;
+  const otherSide: BreastSide = state.activeSide === 'LEFT' ? 'RIGHT' : 'LEFT';
+
+  const pauseDelta = state.isPaused && state.pausedAt
+    ? Math.floor((now.getTime() - state.pausedAt.getTime()) / 1000)
+    : 0;
+
+  switch (action) {
+    case 'switch':
+      return {
+        activeSide: otherSide,
+        leftDuration: accruedLeft,
+        rightDuration: accruedRight,
+        pauseDuration: state.pauseDuration + pauseDelta,
+        pausedAt: null,
+        currentSideStartTime: now,
+        isPaused: false,
+      };
+    case 'pause':
+      return {
+        leftDuration: accruedLeft,
+        rightDuration: accruedRight,
+        currentSideStartTime: null,
+        isPaused: true,
+        pausedAt: now,
+      };
+    case 'resume':
+      return {
+        activeSide: resumeSide || state.activeSide,
+        currentSideStartTime: now,
+        isPaused: false,
+        pauseDuration: state.pauseDuration + pauseDelta,
+        pausedAt: null,
+      };
+    case 'swap':
+      return {
+        activeSide: otherSide,
+        leftDuration: accruedRight,
+        rightDuration: accruedLeft,
+        ...(state.isPaused ? {} : { currentSideStartTime: now }),
+        firstSide: state.firstSide ? (state.firstSide === 'LEFT' ? 'RIGHT' : 'LEFT') : state.firstSide,
+      };
+    default:
+      return null;
+  }
+}

--- a/src/utils/feedSessionActions.ts
+++ b/src/utils/feedSessionActions.ts
@@ -58,6 +58,7 @@ export function applySessionAction(
         isPaused: false,
       };
     case 'pause':
+      if (state.isPaused) return {};
       return {
         leftDuration: accruedLeft,
         rightDuration: accruedRight,

--- a/src/utils/feedSessionLayout.ts
+++ b/src/utils/feedSessionLayout.ts
@@ -1,0 +1,56 @@
+export type BreastSide = 'LEFT' | 'RIGHT';
+
+export interface SessionLayoutInput {
+  sessionStartTime: Date;
+  firstSide?: BreastSide | null;
+  leftDuration: number;
+  rightDuration: number;
+  pauseDuration: number;
+}
+
+export interface SideBlock {
+  side: BreastSide;
+  startTime: Date;
+  endTime: Date;
+  duration: number;
+}
+
+const OTHER_SIDE: Record<BreastSide, BreastSide> = { LEFT: 'RIGHT', RIGHT: 'LEFT' };
+
+function addSeconds(date: Date, seconds: number): Date {
+  return new Date(date.getTime() + seconds * 1000);
+}
+
+export function layoutBreastFeedSession(input: SessionLayoutInput): SideBlock[] {
+  const { sessionStartTime, firstSide, leftDuration, rightDuration, pauseDuration } = input;
+
+  const sides: { side: BreastSide; duration: number }[] = [];
+  if (leftDuration > 0) sides.push({ side: 'LEFT', duration: leftDuration });
+  if (rightDuration > 0) sides.push({ side: 'RIGHT', duration: rightDuration });
+
+  if (sides.length === 0) return [];
+
+  if (firstSide && sides.length === 2) {
+    const firstIndex = sides.findIndex(s => s.side === firstSide);
+    if (firstIndex === 1) {
+      sides.reverse();
+    }
+  } else if (sides.length === 1) {
+    return [{
+      side: sides[0].side,
+      startTime: sessionStartTime,
+      endTime: addSeconds(sessionStartTime, sides[0].duration),
+      duration: sides[0].duration,
+    }];
+  }
+
+  const [first, second] = sides;
+  const firstEnd = addSeconds(sessionStartTime, first.duration);
+  const secondStart = addSeconds(firstEnd, pauseDuration);
+  const secondEnd = addSeconds(secondStart, second.duration);
+
+  return [
+    { side: first.side, startTime: sessionStartTime, endTime: firstEnd, duration: first.duration },
+    { side: second.side, startTime: secondStart, endTime: secondEnd, duration: second.duration },
+  ];
+}

--- a/src/utils/feedSessionLayout.ts
+++ b/src/utils/feedSessionLayout.ts
@@ -15,8 +15,6 @@ export interface SideBlock {
   duration: number;
 }
 
-const OTHER_SIDE: Record<BreastSide, BreastSide> = { LEFT: 'RIGHT', RIGHT: 'LEFT' };
-
 function addSeconds(date: Date, seconds: number): Date {
   return new Date(date.getTime() + seconds * 1000);
 }

--- a/tests/activeBreastFeedActions.test.ts
+++ b/tests/activeBreastFeedActions.test.ts
@@ -30,6 +30,19 @@ describe('applySessionAction — pause accumulation', () => {
     });
   });
 
+  it('pause while already paused is a no-op (preserves original pausedAt)', () => {
+    const originalPausedAt = at('2026-07-20T21:10:00Z');
+    const session = makeSession({
+      leftDuration: 600,
+      isPaused: true,
+      pausedAt: originalPausedAt,
+      currentSideStartTime: null,
+    });
+    const now = at('2026-07-20T21:15:00Z');
+    const result = applySessionAction(session, 'pause', now);
+    expect(result).toEqual({});
+  });
+
   it('resume adds the pause gap to pauseDuration and clears pausedAt', () => {
     const session = makeSession({
       leftDuration: 600,

--- a/tests/activeBreastFeedActions.test.ts
+++ b/tests/activeBreastFeedActions.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { applySessionAction, ActiveBreastFeedState } from '@/src/utils/feedSessionActions';
+
+const at = (iso: string) => new Date(iso);
+
+function makeSession(overrides: Partial<ActiveBreastFeedState> = {}): ActiveBreastFeedState {
+  return {
+    activeSide: 'LEFT',
+    isPaused: false,
+    leftDuration: 0,
+    rightDuration: 0,
+    pauseDuration: 0,
+    pausedAt: null,
+    firstSide: 'LEFT',
+    currentSideStartTime: at('2026-07-20T21:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('applySessionAction — pause accumulation', () => {
+  it('pause sets pausedAt and stops currentSideStartTime', () => {
+    const session = makeSession({ leftDuration: 0 });
+    const now = at('2026-07-20T21:10:00Z');
+    const result = applySessionAction(session, 'pause', now);
+    expect(result).toMatchObject({
+      isPaused: true,
+      pausedAt: now,
+      currentSideStartTime: null,
+      leftDuration: 600,
+    });
+  });
+
+  it('resume adds the pause gap to pauseDuration and clears pausedAt', () => {
+    const session = makeSession({
+      leftDuration: 600,
+      isPaused: true,
+      pausedAt: at('2026-07-20T21:10:00Z'),
+      currentSideStartTime: null,
+    });
+    const now = at('2026-07-20T21:12:00Z');
+    const result = applySessionAction(session, 'resume', now);
+    expect(result).toMatchObject({
+      isPaused: false,
+      pausedAt: null,
+      currentSideStartTime: now,
+      pauseDuration: 120,
+    });
+  });
+
+  it('switch while paused accumulates the pause duration before switching', () => {
+    const session = makeSession({
+      leftDuration: 600,
+      isPaused: true,
+      pausedAt: at('2026-07-20T21:10:00Z'),
+      currentSideStartTime: null,
+    });
+    const now = at('2026-07-20T21:12:00Z');
+    const result = applySessionAction(session, 'switch', now);
+    expect(result).toMatchObject({
+      activeSide: 'RIGHT',
+      isPaused: false,
+      pausedAt: null,
+      pauseDuration: 120,
+      leftDuration: 600,
+      rightDuration: 0,
+    });
+  });
+
+  it('pause while not paused does not add to pauseDuration', () => {
+    const session = makeSession({ leftDuration: 300, currentSideStartTime: at('2026-07-20T21:05:00Z') });
+    const now = at('2026-07-20T21:10:00Z');
+    const result = applySessionAction(session, 'pause', now);
+    expect(result!.pauseDuration).toBeUndefined();
+    expect(result!.leftDuration).toBe(600);
+  });
+});
+
+describe('applySessionAction — switch', () => {
+  it('accumulates elapsed time on the active side before switching', () => {
+    const session = makeSession({ currentSideStartTime: at('2026-07-20T21:00:00Z') });
+    const now = at('2026-07-20T21:10:00Z');
+    const result = applySessionAction(session, 'switch', now);
+    expect(result).toMatchObject({
+      activeSide: 'RIGHT',
+      leftDuration: 600,
+      rightDuration: 0,
+      isPaused: false,
+      currentSideStartTime: now,
+    });
+  });
+});
+
+describe('applySessionAction — swap flips firstSide', () => {
+  it('flips firstSide from LEFT to RIGHT and swaps durations', () => {
+    const now = at('2026-07-20T21:05:00Z');
+    const session = makeSession({
+      leftDuration: 300,
+      rightDuration: 0,
+      firstSide: 'LEFT',
+      currentSideStartTime: now,
+    });
+    const result = applySessionAction(session, 'swap', now);
+    expect(result!.firstSide).toBe('RIGHT');
+    expect(result!.leftDuration).toBe(0);
+    expect(result!.rightDuration).toBe(300);
+  });
+
+  it('preserves null firstSide (legacy session)', () => {
+    const now = at('2026-07-20T21:05:00Z');
+    const session = makeSession({ firstSide: null, currentSideStartTime: now });
+    const result = applySessionAction(session, 'swap', now);
+    expect(result!.firstSide).toBeNull();
+  });
+});
+
+describe('applySessionAction — resume can switch side', () => {
+  it('resumes on a different side when resumeSide is provided', () => {
+    const session = makeSession({ isPaused: true, pausedAt: at('2026-07-20T21:10:00Z'), currentSideStartTime: null });
+    const now = at('2026-07-20T21:12:00Z');
+    const result = applySessionAction(session, 'resume', now, 'RIGHT');
+    expect(result!.activeSide).toBe('RIGHT');
+  });
+});

--- a/tests/feedSessionLayout.test.ts
+++ b/tests/feedSessionLayout.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { layoutBreastFeedSession, SideBlock } from '@/src/utils/feedSessionLayout';
+
+const at = (iso: string) => new Date(iso);
+const diffSec = (a: Date, b: Date) => (b.getTime() - a.getTime()) / 1000;
+
+describe('layoutBreastFeedSession', () => {
+  it('lays out LEFT then RIGHT contiguously when firstSide is LEFT and no pause', () => {
+    const start = at('2026-07-20T21:00:00Z');
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: start,
+      firstSide: 'LEFT',
+      leftDuration: 600,
+      rightDuration: 600,
+      pauseDuration: 0,
+    });
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({ side: 'LEFT', duration: 600 });
+    expect(blocks[0].startTime).toEqual(start);
+    expect(blocks[0].endTime).toEqual(at('2026-07-20T21:10:00Z'));
+    expect(blocks[1]).toMatchObject({ side: 'RIGHT', duration: 600 });
+    expect(blocks[1].startTime).toEqual(at('2026-07-20T21:10:00Z'));
+    expect(blocks[1].endTime).toEqual(at('2026-07-20T21:20:00Z'));
+  });
+
+  it('orders RIGHT then LEFT when firstSide is RIGHT', () => {
+    const start = at('2026-07-20T21:00:00Z');
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: start,
+      firstSide: 'RIGHT',
+      leftDuration: 600,
+      rightDuration: 600,
+      pauseDuration: 0,
+    });
+    expect(blocks[0].side).toBe('RIGHT');
+    expect(blocks[1].side).toBe('LEFT');
+    expect(blocks[1].endTime).toEqual(at('2026-07-20T21:20:00Z'));
+  });
+
+  it('inserts the pause gap between the two side blocks', () => {
+    const start = at('2026-07-20T21:00:00Z');
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: start,
+      firstSide: 'LEFT',
+      leftDuration: 600,
+      rightDuration: 600,
+      pauseDuration: 120,
+    });
+    expect(blocks).toHaveLength(2);
+    expect(diffSec(blocks[0].endTime, blocks[1].startTime)).toBe(120);
+    expect(blocks[1].endTime).toEqual(at('2026-07-20T21:22:00Z'));
+  });
+
+  it('consolidates alternating sides (L→R→L→R) into two contiguous blocks', () => {
+    const start = at('2026-07-20T21:00:00Z');
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: start,
+      firstSide: 'LEFT',
+      leftDuration: 1200,
+      rightDuration: 1200,
+      pauseDuration: 120,
+    });
+    expect(blocks[0].side).toBe('LEFT');
+    expect(blocks[0].startTime).toEqual(start);
+    expect(blocks[0].endTime).toEqual(at('2026-07-20T21:20:00Z'));
+    expect(blocks[1].side).toBe('RIGHT');
+    expect(blocks[1].startTime).toEqual(at('2026-07-20T21:22:00Z'));
+    expect(blocks[1].endTime).toEqual(at('2026-07-20T21:42:00Z'));
+  });
+
+  it('returns a single block when only one side has duration (pause ignored for layout)', () => {
+    const start = at('2026-07-20T21:00:00Z');
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: start,
+      firstSide: 'LEFT',
+      leftDuration: 900,
+      rightDuration: 0,
+      pauseDuration: 60,
+    });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].side).toBe('LEFT');
+    expect(blocks[0].startTime).toEqual(start);
+    expect(blocks[0].endTime).toEqual(at('2026-07-20T21:15:00Z'));
+  });
+
+  it('returns empty when both sides have zero duration', () => {
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: at('2026-07-20T21:00:00Z'),
+      firstSide: 'LEFT',
+      leftDuration: 0,
+      rightDuration: 0,
+      pauseDuration: 0,
+    });
+    expect(blocks).toHaveLength(0);
+  });
+
+  it('falls back to LEFT first when firstSide is null/undefined and both sides have time', () => {
+    const start = at('2026-07-20T21:00:00Z');
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: start,
+      firstSide: null,
+      leftDuration: 600,
+      rightDuration: 600,
+      pauseDuration: 0,
+    });
+    expect(blocks[0].side).toBe('LEFT');
+    expect(blocks[1].side).toBe('RIGHT');
+  });
+
+  it('honours duration overrides (e.g. from form adjustments)', () => {
+    const start = at('2026-07-20T21:00:00Z');
+    const blocks = layoutBreastFeedSession({
+      sessionStartTime: start,
+      firstSide: 'LEFT',
+      leftDuration: 300,
+      rightDuration: 300,
+      pauseDuration: 0,
+    });
+    expect(blocks[0].endTime).toEqual(at('2026-07-20T21:05:00Z'));
+    expect(blocks[1].endTime).toEqual(at('2026-07-20T21:10:00Z'));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the breastfeeding active-session timer so each side's recorded span reflects when it was actually in use, and pauses within a nursing session are tracked and visible. Closes #229.

## Problem

`endBreastfeedSession` created one `FeedLog` row per side but gave **both** rows `startTime = session.sessionStartTime` (the last side got `+10ms` only to sort first) and `endTime = now`. With LEFT for 10m starting at 21:00 and RIGHT for 10m after, both rows showed `21:00–21:20`, so the right side appeared to start at session start. Pauses (e.g. to burp the baby) were not recorded anywhere — `pause` just nulled `currentSideStartTime` and the elapsed wall-clock time disappeared.

## Changes

- **Schema**: add `pauseDuration`, `pausedAt`, `firstSide` to `ActiveBreastFeed`; add `pauseDuration` to `FeedLog` (session-level pause, same value on all rows of a session; nullable for legacy rows).
- **Layout**: new pure `src/utils/feedSessionLayout.ts` lays out per-side blocks sequentially in first-use order: 1st side `[sessionStart, sessionStart + sideTotal]`, pause gap, 2nd side `[prevEnd + pauseDuration, + sideTotal]`. Alternating sides (L→R→L→R) still produce exactly two rows, consolidated by side.
- **Actions**: new pure `src/utils/feedSessionActions.ts` extracts `applySessionAction` so timer transitions are unit-testable without a database. `switch` while paused now accumulates the pause before switching; `swap` flips `firstSide` so the "used first" order follows the correction; `pause` while already paused is a no-op (a duplicate request can't discard accumulated pause time).
- **End session**: `endBreastfeedSession` uses the layout helper to write real per-side `startTime`/`endTime` + `pauseDuration` on each row; the `+10ms` sort hack is removed. Legacy in-flight sessions (null `firstSide`) fall back to the opposite of `activeSide` to preserve the previous sort order.
- **Display**: feed entry details (Timeline + FullLog, both via `getActivityDetails`) show a `Pause` line with `mm:ss` when `pauseDuration > 0`, using the existing `t('Pause')` key.
- **Surfaces fixed at once**: `/api/active-breastfeed` (app + nursery mode) and `/api/hooks/v1/babies/[babyId]/activities` (external integrations) all share `endBreastfeedSession`/`updateBreastfeedSession`, so every active-session path is corrected.

## Example

L 10m starting 21:00, R 10m, L 10m, R 10m, with a 2m pause mid-session → totals L=20m, R=20m, pause=2m:

- LEFT row: `21:00 – 21:20`, `feedDuration: 1200`, `pauseDuration: 120`
- RIGHT row: `21:22 – 21:42`, `feedDuration: 1200`, `pauseDuration: 120`

## Backwards compatibility

- `pauseDuration` on `FeedLog` is nullable; older rows show no pause.
- `firstSide` on `ActiveBreastFeed` is nullable; legacy in-flight sessions fall back to the opposite of `activeSide`.
- Grouping via `sessionId` + `groupBreastFeedSessions` is unchanged — a session still counts and displays as one feed with two sides.

## Tests

- `tests/feedSessionLayout.test.ts`: L→R ordering, pause gap insertion, alternating consolidation, right-first, single side, both-zero, null `firstSide` fallback, duration overrides.
- `tests/activeBreastFeedActions.test.ts`: pause/resume accumulation, switch-while-paused, double-pause no-op, swap flips `firstSide`, resume side switch, legacy `firstSide` preserved.
- Full suite: 424/424 passing. (5 pre-existing suite failures from missing optional deps `csv-parse`/`exif-reader` are unrelated and present on `main`.)