### PR TITLE
Localize hardcoded age strings (more missing translation keys)

### DIFF
--- a/app/(app)/[slug]/client-layout.tsx
+++ b/app/(app)/[slug]/client-layout.tsx
@@ -125,11 +125,11 @@ function AppContent({ children }: { children: React.ReactNode }) {
     const ageInYears = Math.floor((today.getTime() - birthDate.getTime()) / (1000 * 60 * 60 * 24 * 365.25));
     
     if (ageInMonths < 6) {
-      return `${ageInWeeks} weeks`;
+      return `${ageInWeeks} ${ageInWeeks === 1 ? t('week') : t('weeks')}`;
     } else if (ageInMonths < 24) {
-      return `${ageInMonths} months`;
+      return `${ageInMonths} ${ageInMonths === 1 ? t('month') : t('months')}`;
     } else {
-      return `${ageInYears} ${ageInYears === 1 ? 'year' : 'years'}`;
+      return `${ageInYears} ${ageInYears === 1 ? t('year') : t('years')}`;
     }
   };
 

--- a/src/components/account-manager/FamilyPeopleTab.tsx
+++ b/src/components/account-manager/FamilyPeopleTab.tsx
@@ -118,16 +118,18 @@ const FamilyPeopleTab: React.FC<FamilyPeopleTabProps> = ({
     const now = new Date();
     const diffTime = Math.abs(now.getTime() - birthDate.getTime());
     const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-    
+
     if (diffDays < 30) {
-      return `${diffDays} days old`;
+      return `${diffDays} ${diffDays === 1 ? t('day old') : t('days old')}`;
     } else if (diffDays < 365) {
       const months = Math.floor(diffDays / 30);
-      return `${months} month${months > 1 ? 's' : ''} old`;
+      return `${months} ${months === 1 ? t('month old') : t('months old')}`;
     } else {
       const years = Math.floor(diffDays / 365);
       const remainingMonths = Math.floor((diffDays % 365) / 30);
-      return `${years} year${years > 1 ? 's' : ''} ${remainingMonths > 0 ? `${remainingMonths} month${remainingMonths > 1 ? 's' : ''}` : ''} old`.trim();
+      const yearStr = `${years} ${years === 1 ? t('year') : t('years')}`;
+      const monthStr = remainingMonths > 0 ? ` ${remainingMonths} ${remainingMonths === 1 ? t('month') : t('months')}` : '';
+      return `${yearStr}${monthStr} ${t('old')}`;
     }
   };
 

--- a/src/localization/translations/en.json
+++ b/src/localization/translations/en.json
@@ -2567,5 +2567,12 @@
   "Your payment was processed, but we encountered an issue activating your account. Please contact support or try logging out and back in.": "Your payment was processed, but we encountered an issue activating your account. Please contact support or try logging out and back in.",
   "Your Personal PIN (6-10 digits)": "Your Personal PIN (6-10 digits)",
   "Your Personal Profile": "Your Personal Profile",
-  "Zero “did anyone change him?” texts sent today.": "Zero “did anyone change him?” texts sent today."
+  "Zero “did anyone change him?” texts sent today.": "Zero “did anyone change him?” texts sent today.",
+  "week": "week",
+  "month": "month",
+  "year": "year",
+  "day old": "day old",
+  "days old": "days old",
+  "month old": "month old",
+  "old": "old"
 }


### PR DESCRIPTION
Replaces hardcoded English age strings with localized `t()` calls and adds the corresponding keys to `en.json`.

## Changes
- `app/(app)/[slug]/client-layout.tsx` — localize `week(s)`/`month(s)`/`year(s)` in the age label.
- `src/components/account-manager/FamilyPeopleTab.tsx` — localize `day(s) old`/`month(s)`/`year(s)`/`old` in the person age label.
- `src/localization/translations/en.json` — add the new keys.

Cherry-picked from commit 665cd2b5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)