### PR TITLE
fix: align mixed-bottle value with its translation key

### DIFF
--- a/app/api/breast-milk-balance/route.ts
+++ b/app/api/breast-milk-balance/route.ts
@@ -49,13 +49,13 @@ async function handleGet(req: NextRequest, authContext: AuthResult) {
       select: { amount: true, unitAbbr: true },
     });
 
-    // 3. Sum of bottle feeds with bottleType "Breast Milk" or "Formula\Breast"
+    // 3. Sum of bottle feeds with bottleType "Breast Milk" or "Formula/Breast"
     const feedLogs = await prisma.feedLog.findMany({
       where: {
         babyId,
         familyId: userFamilyId,
         type: 'BOTTLE',
-        bottleType: { in: ['Breast Milk', 'Formula\\Breast'] },
+        bottleType: { in: ['Breast Milk', 'Formula/Breast'] },
         deletedAt: null,
       },
       select: { amount: true, unitAbbr: true, bottleType: true, breastMilkAmount: true, sourcePumpId: true, notes: true },

--- a/prisma/migrations/20260720120000_fix_mixed_bottle_type_slash/migration.sql
+++ b/prisma/migrations/20260720120000_fix_mixed_bottle_type_slash/migration.sql
@@ -1,0 +1,3 @@
+-- Align the mixed-bottle value with its translation key: 'Formula\Breast' -> 'Formula/Breast'.
+-- Backslash is a literal character in standard SQL string literals on both SQLite and PostgreSQL.
+UPDATE "FeedLog" SET "bottleType" = 'Formula/Breast' WHERE "bottleType" = 'Formula\Breast';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -400,8 +400,8 @@ model FeedLog {
   hadReaction  Boolean     @default(false) // True when this feed caused a reaction (e.g. a formula intolerance)
   reactionDescription String? // Description of the reaction (redness, swelling, ...)
   reactionCause String? // What caused the reaction (e.g. a formula name like "Similac")
-  bottleType   String? // Type of bottle feed: formula, breast milk, formula\breast, milk, other
-  breastMilkAmount Float? // Breast milk amount used (for Formula\Breast mixed feeds)
+  bottleType   String? // Type of bottle feed: formula, breast milk, formula/breast, milk, other
+  breastMilkAmount Float? // Breast milk amount used (for Formula/Breast mixed feeds)
   sessionId    String? // Groups breast feeds into one nursing session; a unique value opts a feed out of heuristic grouping
   sourcePumpId String? @unique // Links an automatic breast-milk feed to the pump session that created it
   createdAt    DateTime    @default(now())

--- a/src/components/FullLogTimeline/index.tsx
+++ b/src/components/FullLogTimeline/index.tsx
@@ -23,6 +23,7 @@ import { getActivityEndpoint, getActivityTime } from '@/src/components/Timeline/
 import { PumpLogResponse, MedicineLogResponse, BreastMilkAdjustmentResponse, PlayLogResponse, VaccineLogResponse, FoodLogResponse } from '@/app/api/types';
 import { cn } from '@/src/lib/utils';
 import styles from './full-log-timeline.styles';
+import { useLocalization } from '@/src/context/localization';
 import './full-log-timeline.css';
 
 /**
@@ -39,6 +40,7 @@ const FullLogTimeline: React.FC<FullLogTimelineProps> = ({
   onDateRangeChange,
   babyId,
 }) => {
+  const { t } = useLocalization();
   const [settings, setSettings] = useState<Settings | null>(null);
   const [selectedActivity, setSelectedActivity] = useState<ActivityType | null>(null);
   const [activeFilter, setActiveFilter] = useState<FilterType>(null);
@@ -183,7 +185,7 @@ const FullLogTimeline: React.FC<FullLogTimelineProps> = ({
       if (activity.side && activity.side.toLowerCase().includes(searchLower)) return true;
       if (activity.food && activity.food.toLowerCase().includes(searchLower)) return true;
       if (activity.notes && activity.notes.toLowerCase().includes(searchLower)) return true;
-      if (activity.bottleType && activity.bottleType.toLowerCase().includes(searchLower)) return true;
+      if (activity.bottleType && (activity.bottleType.toLowerCase().includes(searchLower) || t(activity.bottleType.replace('\\', '/')).toLowerCase().includes(searchLower))) return true;
       return false;
     }
     
@@ -266,7 +268,7 @@ const FullLogTimeline: React.FC<FullLogTimelineProps> = ({
     }
 
     return false;
-  }, []);
+  }, [t]);
 
   const breastMilkTrackingEnabled = (settings as any)?.enableBreastMilkTracking ?? true;
 

--- a/src/components/FullLogTimeline/index.tsx
+++ b/src/components/FullLogTimeline/index.tsx
@@ -185,7 +185,7 @@ const FullLogTimeline: React.FC<FullLogTimelineProps> = ({
       if (activity.side && activity.side.toLowerCase().includes(searchLower)) return true;
       if (activity.food && activity.food.toLowerCase().includes(searchLower)) return true;
       if (activity.notes && activity.notes.toLowerCase().includes(searchLower)) return true;
-      if (activity.bottleType && (activity.bottleType.toLowerCase().includes(searchLower) || t(activity.bottleType.replace('\\', '/')).toLowerCase().includes(searchLower))) return true;
+      if (activity.bottleType && (activity.bottleType.toLowerCase().includes(searchLower) || t(activity.bottleType).toLowerCase().includes(searchLower))) return true;
       return false;
     }
     

--- a/src/components/Reports/FeedingChartModal.tsx
+++ b/src/components/Reports/FeedingChartModal.tsx
@@ -356,7 +356,7 @@ const FeedingChartModal: React.FC<FeedingChartModalProps> = ({
                         key={type}
                         yAxisId="amount"
                         dataKey={type}
-                        name={t(type.replace('\\', '/'))}
+                        name={t(type)}
                         stackId="bottles"
                         fill={bottleData.colors[index]}
                       />
@@ -370,7 +370,7 @@ const FeedingChartModal: React.FC<FeedingChartModalProps> = ({
                     { key: 'count', label: t('Feed Count') },
                     ...bottleData.bottleTypes.map((type) => ({
                       key: type,
-                      label: t(type.replace('\\', '/')),
+                      label: t(type),
                     })),
                   ]}
                   rows={bottleData.data.map((point: any) => ({

--- a/src/components/Reports/FeedingStatsSection.tsx
+++ b/src/components/Reports/FeedingStatsSection.tsx
@@ -68,7 +68,7 @@ const FeedingStatsSection: React.FC<FeedingStatsSectionProps> = ({ stats, activi
                   <div className={cn(styles.statCardSubLabel, "reports-stat-card-sublabel")}>
                     {stats.bottleFeeds.avgByType.map((bt, idx) => (
                       <span key={bt.type}>
-                        {t(bt.type.replace('\\', '/'))}: {bt.avgAmount.toFixed(1)} {unitSymbol(bt.unit)} avg
+                        {t(bt.type)}: {bt.avgAmount.toFixed(1)} {unitSymbol(bt.unit)} avg
                         {idx < stats.bottleFeeds.avgByType.length - 1 ? ', ' : ''}
                       </span>
                     ))}

--- a/src/components/Reports/FeedingStatsSection.tsx
+++ b/src/components/Reports/FeedingStatsSection.tsx
@@ -68,7 +68,7 @@ const FeedingStatsSection: React.FC<FeedingStatsSectionProps> = ({ stats, activi
                   <div className={cn(styles.statCardSubLabel, "reports-stat-card-sublabel")}>
                     {stats.bottleFeeds.avgByType.map((bt, idx) => (
                       <span key={bt.type}>
-                        {bt.type}: {bt.avgAmount.toFixed(1)} {unitSymbol(bt.unit)} avg
+                        {t(bt.type.replace('\\', '/'))}: {bt.avgAmount.toFixed(1)} {unitSymbol(bt.unit)} avg
                         {idx < stats.bottleFeeds.avgByType.length - 1 ? ', ' : ''}
                       </span>
                     ))}

--- a/src/components/Reports/PumpingChartModal.tsx
+++ b/src/components/Reports/PumpingChartModal.tsx
@@ -250,7 +250,7 @@ const PumpingChartModal: React.FC<PumpingChartModalProps> = ({
           let bmConsumed = 0;
           if (feedActivity.bottleType === 'Breast Milk' && feedActivity.amount) {
             bmConsumed = convertVolume(feedActivity.amount, feedActivity.unitAbbr || 'OZ', targetUnit);
-          } else if (feedActivity.bottleType === 'Formula\\Breast' && feedActivity.breastMilkAmount) {
+          } else if (feedActivity.bottleType === 'Formula/Breast' && feedActivity.breastMilkAmount) {
             bmConsumed = convertVolume(feedActivity.breastMilkAmount, feedActivity.unitAbbr || 'OZ', targetUnit);
           }
           if (bmConsumed > 0) {

--- a/src/components/Timeline/TimelineV2/TimelineV2ActivityList.tsx
+++ b/src/components/Timeline/TimelineV2/TimelineV2ActivityList.tsx
@@ -398,8 +398,7 @@ const TimelineV2ActivityList = ({
                                         const unit = ((activity as any).unitAbbr || 'oz').toLowerCase();
                                         const parts = [];
                                         if ((activity as any).bottleType) {
-                                          const bottleType = (activity as any).bottleType.replace('\\', '/');
-                                          parts.push(t(bottleType));
+                                          parts.push(t((activity as any).bottleType));
                                         }
                                         parts.push(`${activity.amount} ${unit}`);
                                         if ((activity as any).hadReaction) parts.push(t('Reaction'));

--- a/src/components/Timeline/utils.tsx
+++ b/src/components/Timeline/utils.tsx
@@ -339,7 +339,7 @@ export const getActivityDetails = (activity: ActivityType, settings: Settings | 
       // Show amount for bottle and solids - use unitAbbr instead of hardcoded units
       if (activity.amount && (activity.type === 'BOTTLE' || activity.type === 'SOLIDS')) {
         const unit = (activity as any).unitAbbr || (activity.type === 'BOTTLE' ? 'oz' : 'g');
-        if ((activity as any).bottleType === 'Formula\\Breast' && (activity as any).breastMilkAmount != null) {
+        if ((activity as any).bottleType === 'Formula/Breast' && (activity as any).breastMilkAmount != null) {
           const bmAmt = (activity as any).breastMilkAmount;
           const formulaAmt = Math.round((activity.amount - bmAmt) * 100) / 100;
           details.push({ label: t('Breast Milk Amount'), value: `${bmAmt} ${unit}` });
@@ -384,7 +384,7 @@ export const getActivityDetails = (activity: ActivityType, settings: Settings | 
         const bottleType = (activity as any).bottleType;
         details.push({
           label: t('Bottle Type'),
-          value: t(bottleType.replace('\\', '/'))
+          value: t(bottleType)
         });
       }
 
@@ -826,7 +826,7 @@ export const getActivityDescription = (activity: ActivityType, settings: Setting
         // Use unitAbbr instead of hardcoded 'oz'
         const unit = ((activity as any).unitAbbr || 'oz').toLowerCase();
 
-        if ((activity as any).bottleType === 'Formula\\Breast' && (activity as any).breastMilkAmount != null) {
+        if ((activity as any).bottleType === 'Formula/Breast' && (activity as any).breastMilkAmount != null) {
           const bmAmt = (activity as any).breastMilkAmount;
           const formulaAmt = Math.round((((activity as any).amount || 0) - bmAmt) * 100) / 100;
           details = `${bmAmt} ${unit} ${t('BM')} + ${formulaAmt} ${unit} ${t('Formula')}`;
@@ -835,10 +835,10 @@ export const getActivityDescription = (activity: ActivityType, settings: Setting
         }
 
         // Add bottle type if available (skip for mixed since already shown above)
-        if ((activity as any).bottleType && (activity as any).bottleType !== 'Formula\\Breast') {
-          const bottleType = (activity as any).bottleType.replace('\\', '/');
+        if ((activity as any).bottleType && (activity as any).bottleType !== 'Formula/Breast') {
+          const bottleType = (activity as any).bottleType;
           details += ` (${t(bottleType)})`;
-        } else if ((activity as any).bottleType === 'Formula\\Breast' && !(activity as any).breastMilkAmount) {
+        } else if ((activity as any).bottleType === 'Formula/Breast' && !(activity as any).breastMilkAmount) {
           details += ` (${t('Formula/Breast')})`;
         }
       } else if (activity.type === 'SOLIDS') {

--- a/src/components/forms/FeedForm/BottleFeedForm.tsx
+++ b/src/components/forms/FeedForm/BottleFeedForm.tsx
@@ -52,7 +52,7 @@ export default function BottleFeedForm({
   const { t } = useLocalization();
   const { unitSymbol } = useUnit();
   const formId = useId();
-  const bottleTypes = ['Formula', 'Breast Milk', 'Formula\\Breast', 'Milk', 'Other'];
+  const bottleTypes = ['Formula', 'Breast Milk', 'Formula/Breast', 'Milk', 'Other'];
   
   return (
     <div>
@@ -67,11 +67,11 @@ export default function BottleFeedForm({
             onClick={() => onBottleTypeChange(type)}
             disabled={loading}
           >
-            {t(type.replace('\\', '/'))}
+            {t(type)}
           </Button>
         ))}
       </div>
-      {bottleType === 'Formula\\Breast' ? (
+      {bottleType === 'Formula/Breast' ? (
         <div className="grid grid-cols-2 gap-4 mb-6">
           <div>
             <label htmlFor={`${formId}-breast-milk-amount`} className="form-label mb-2">{t('Breast Milk Amount')} ({unitSymbol(unit)})</label>

--- a/src/components/forms/FeedForm/index.tsx
+++ b/src/components/forms/FeedForm/index.tsx
@@ -219,7 +219,7 @@ export default function FeedForm({
           ...prev,
           amount: data.data.amount.toString(),
           unit: data.data.unitAbbr || prev.unit,
-          ...(lastBottleType === 'Formula\\Breast' && lastBmAmount != null ? {
+          ...(lastBottleType === 'Formula/Breast' && lastBmAmount != null ? {
             breastMilkAmount: lastBmAmount.toString(),
             formulaAmount: (data.data.amount - lastBmAmount).toString(),
           } : {}),
@@ -380,9 +380,9 @@ export default function FeedForm({
         reactionDescription: (activity as any).reactionDescription || '',
         reactionCause: (activity as any).reactionCause || '',
         bottleType: activityBottleType,
-        breastMilkAmount: activityBottleType === 'Formula\\Breast' && activityBmAmount != null
+        breastMilkAmount: activityBottleType === 'Formula/Breast' && activityBmAmount != null
           ? activityBmAmount.toString() : '',
-        formulaAmount: activityBottleType === 'Formula\\Breast' && activityBmAmount != null && activity.amount != null
+        formulaAmount: activityBottleType === 'Formula/Breast' && activityBmAmount != null && activity.amount != null
           ? (activity.amount - activityBmAmount).toString() : '',
         feedDuration: feedDuration,
         leftDuration: activity.side === 'LEFT' ? feedDuration : 0,
@@ -577,7 +577,7 @@ export default function FeedForm({
 
     // For bottle feeding, validate amount
     if (formData.type === 'BOTTLE') {
-      if (formData.bottleType === 'Formula\\Breast') {
+      if (formData.bottleType === 'Formula/Breast') {
         const bmAmt = parseFloat(formData.breastMilkAmount || '0');
         const fAmt = parseFloat(formData.formulaAmount || '0');
         if (bmAmt <= 0 || fAmt <= 0) {
@@ -747,12 +747,12 @@ export default function FeedForm({
         feedDuration: duration
       }),
       ...(formData.type === 'BOTTLE' && {
-        amount: formData.bottleType === 'Formula\\Breast'
+        amount: formData.bottleType === 'Formula/Breast'
           ? parseFloat(formData.breastMilkAmount || '0') + parseFloat(formData.formulaAmount || '0')
           : parseFloat(formData.amount),
         unitAbbr: formData.unit,
       }),
-      ...(formData.type === 'BOTTLE' && formData.bottleType === 'Formula\\Breast' && {
+      ...(formData.type === 'BOTTLE' && formData.bottleType === 'Formula/Breast' && {
         breastMilkAmount: parseFloat(formData.breastMilkAmount || '0'),
       }),
       ...(formData.type === 'BOTTLE' && formData.bottleType && { bottleType: formData.bottleType }),

--- a/src/utils/breastMilkInventory.ts
+++ b/src/utils/breastMilkInventory.ts
@@ -108,7 +108,7 @@ export function calculateBreastMilkBalance({
       return total + convertVolume(log.amount, log.unitAbbr || 'OZ', targetUnit);
     }
 
-    if (log.bottleType === 'Formula\\Breast' && log.breastMilkAmount != null) {
+    if (log.bottleType === 'Formula/Breast' && log.breastMilkAmount != null) {
       return total + convertVolume(log.breastMilkAmount, log.unitAbbr || 'OZ', targetUnit);
     }
 

--- a/src/utils/feedTimerConfig.ts
+++ b/src/utils/feedTimerConfig.ts
@@ -23,7 +23,7 @@ export interface FeedTimerFeedLike {
   bottleType?: string | null;
 }
 
-const MIXED_BOTTLE = 'Formula\\Breast';
+const MIXED_BOTTLE = 'Formula/Breast';
 const BREAST_MILK_BOTTLES = ['Breast Milk', MIXED_BOTTLE];
 const FORMULA_BOTTLES = ['Formula', MIXED_BOTTLE];
 const KNOWN_BOTTLE_TYPES = ['Breast Milk', 'Formula', MIXED_BOTTLE];

--- a/tests/breastMilkInventory.test.ts
+++ b/tests/breastMilkInventory.test.ts
@@ -57,7 +57,7 @@ describe('breast milk inventory', () => {
         {
           amount: 6,
           unitAbbr: 'ML',
-          bottleType: 'Formula\\Breast',
+          bottleType: 'Formula/Breast',
           breastMilkAmount: 2,
           sourcePumpId: null,
           notes: null,

--- a/tests/feedTimerConfig.test.ts
+++ b/tests/feedTimerConfig.test.ts
@@ -103,10 +103,10 @@ describe('feedCountsForTimer', () => {
     expect(feedCountsForTimer({ type: 'BOTTLE', bottleType: 'Formula' }, ['BOTTLE_BREAST_MILK'])).toBe(false);
   });
 
-  it('counts mixed Formula\\Breast bottles under either breast-milk or formula', () => {
-    expect(feedCountsForTimer({ type: 'BOTTLE', bottleType: 'Formula\\Breast' }, ['BOTTLE_BREAST_MILK'])).toBe(true);
-    expect(feedCountsForTimer({ type: 'BOTTLE', bottleType: 'Formula\\Breast' }, ['BOTTLE_FORMULA'])).toBe(true);
-    expect(feedCountsForTimer({ type: 'BOTTLE', bottleType: 'Formula\\Breast' }, ['BREAST'])).toBe(false);
+  it('counts mixed Formula/Breast bottles under either breast-milk or formula', () => {
+    expect(feedCountsForTimer({ type: 'BOTTLE', bottleType: 'Formula/Breast' }, ['BOTTLE_BREAST_MILK'])).toBe(true);
+    expect(feedCountsForTimer({ type: 'BOTTLE', bottleType: 'Formula/Breast' }, ['BOTTLE_FORMULA'])).toBe(true);
+    expect(feedCountsForTimer({ type: 'BOTTLE', bottleType: 'Formula/Breast' }, ['BREAST'])).toBe(false);
   });
 
   it('treats Milk, Other, unknown and missing bottle types as BOTTLE_OTHER', () => {
@@ -149,10 +149,10 @@ describe('buildFeedTimerWhere', () => {
 
   it('includes mixed bottles in both breast-milk and formula clauses', () => {
     expect(buildFeedTimerWhere(['BOTTLE_BREAST_MILK'])).toEqual({
-      OR: [{ type: 'BOTTLE', bottleType: { in: ['Breast Milk', 'Formula\\Breast'] } }],
+      OR: [{ type: 'BOTTLE', bottleType: { in: ['Breast Milk', 'Formula/Breast'] } }],
     });
     expect(buildFeedTimerWhere(['BOTTLE_FORMULA'])).toEqual({
-      OR: [{ type: 'BOTTLE', bottleType: { in: ['Formula', 'Formula\\Breast'] } }],
+      OR: [{ type: 'BOTTLE', bottleType: { in: ['Formula', 'Formula/Breast'] } }],
     });
   });
 
@@ -163,7 +163,7 @@ describe('buildFeedTimerWhere', () => {
           type: 'BOTTLE',
           OR: [
             { bottleType: null },
-            { bottleType: { notIn: ['Breast Milk', 'Formula', 'Formula\\Breast'] } },
+            { bottleType: { notIn: ['Breast Milk', 'Formula', 'Formula/Breast'] } },
           ],
         },
       ],
@@ -182,7 +182,7 @@ describe('buildFeedTimerWhere', () => {
     expect(where).toEqual({
       OR: [
         { type: 'BREAST' },
-        { type: 'BOTTLE', bottleType: { in: ['Formula', 'Formula\\Breast'] } },
+        { type: 'BOTTLE', bottleType: { in: ['Formula', 'Formula/Breast'] } },
       ],
     });
   });


### PR DESCRIPTION
## What

The mixed-bottle type is stored as `Formula\Breast` (backslash) while its i18n key is `Formula/Breast` (slash). The mismatch forced a `.replace('\\', '/')` workaround before every `t()` call — scattered across **8 sites in 6 files** — and any site that displays `bottleType` without that workaround shows the raw backslash.

## Change

- Align the stored value to `Formula/Breast` everywhere (constant, forms, timeline, reports, inventory, API query).
- Drop all 8 `.replace('\\', '/')` workarounds — now no-ops.
- Migration `20260720120000_fix_mixed_bottle_type_slash` rewrites existing `FeedLog` rows (`UPDATE ... WHERE bottleType = 'Formula\Breast'`). One SQL works for both SQLite and PostgreSQL (backslash is a literal in standard string literals).
- Fixed the `breast-milk-balance` API query so it matches the migrated value.

## Notes

- First commit (`translate bottle types`) is cherry-picked from a downstream branch; it added two of the `.replace` workarounds. This PR is the clean follow-up that removes the need for them.
- All 672 tests pass. Pre-existing recharts `Formatter` typecheck errors are unrelated (present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)