### PR TITLE
fix(security): strengthen family-level access controls

### DIFF
--- a/app/api/baby/route.ts
+++ b/app/api/baby/route.ts
@@ -6,6 +6,7 @@ import { toUTC, formatForResponse } from '../utils/timezone';
 import { withAuthContext, AuthResult } from '../utils/auth';
 import { checkWritePermission } from '../utils/writeProtection';
 import { isValidFeedTimerTypes } from '@/src/utils/feedTimerConfig';
+import { resolveFamilyScope } from '../utils/family-scope';
 
 async function handlePost(req: NextRequest, authContext: AuthResult) {
   // Check write permissions for expired accounts
@@ -15,8 +16,6 @@ async function handlePost(req: NextRequest, authContext: AuthResult) {
   }
 
   try {
-    const { familyId: userFamilyId, isSetupAuth, isSysAdmin, isAccountAuth } = authContext;
-    
     const requestBody = await req.json();
     const { familyId: bodyFamilyId, ...babyData } = requestBody;
     const body: BabyCreate = babyData;
@@ -28,15 +27,14 @@ async function handlePost(req: NextRequest, authContext: AuthResult) {
       );
     }
 
-    // Determine target family ID - prefer auth context, but allow body override for setup auth, account auth, and sysadmin
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && (isSetupAuth || isSysAdmin || isAccountAuth) && bodyFamilyId) {
-      targetFamilyId = bodyFamilyId;
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
+
+    const scope = resolveFamilyScope(authContext, bodyFamilyId ?? queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-    
-    if (!targetFamilyId) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
+    const targetFamilyId = scope.familyId;
 
     const baby = await prisma.baby.create({
       data: {
@@ -88,8 +86,6 @@ async function handlePut(req: NextRequest, authContext: AuthResult) {
   }
 
   try {
-    const { familyId: userFamilyId, isSysAdmin } = authContext;
-    
     const requestBody = await req.json();
     const { id, familyId: bodyFamilyId, ...updateData } = requestBody;
     const body: BabyUpdate = { id, ...updateData };
@@ -101,15 +97,14 @@ async function handlePut(req: NextRequest, authContext: AuthResult) {
       );
     }
 
-    // For system administrators, allow familyId to be specified in request body
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && isSysAdmin && bodyFamilyId) {
-      targetFamilyId = bodyFamilyId;
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
+
+    const scope = resolveFamilyScope(authContext, bodyFamilyId ?? queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-    
-    if (!targetFamilyId) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
+    const targetFamilyId = scope.familyId;
 
     const existingBaby = await prisma.baby.findFirst({
       where: { id, familyId: targetFamilyId },
@@ -166,11 +161,9 @@ async function handleDelete(req: NextRequest, authContext: AuthResult) {
   }
 
   try {
-    const { familyId: userFamilyId, isSysAdmin } = authContext;
-    
     const { searchParams } = new URL(req.url);
     const id = searchParams.get('id');
-    const familyId = searchParams.get('familyId');
+    const queryFamilyId = searchParams.get('familyId');
 
     if (!id) {
       return NextResponse.json<ApiResponse>(
@@ -182,15 +175,11 @@ async function handleDelete(req: NextRequest, authContext: AuthResult) {
       );
     }
 
-    // For system administrators, allow familyId to be specified as query parameter
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && isSysAdmin && familyId) {
-      targetFamilyId = familyId;
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-    
-    if (!targetFamilyId) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
+    const targetFamilyId = scope.familyId;
 
     // Verify baby belongs to user's family before deleting
     const existingBaby = await prisma.baby.findFirst({
@@ -230,22 +219,16 @@ async function handleDelete(req: NextRequest, authContext: AuthResult) {
 
 async function handleGet(req: NextRequest, authContext: AuthResult) {
   try {
-    const { familyId: userFamilyId, isSysAdmin } = authContext;
-    
     const { searchParams } = new URL(req.url);
     const id = searchParams.get('id');
-    const familyId = searchParams.get('familyId');
-    
-    // For system administrators, allow familyId to be specified as query parameter
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && isSysAdmin && familyId) {
-      targetFamilyId = familyId;
+    const queryFamilyId = searchParams.get('familyId');
+
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-    
-    if (!targetFamilyId) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
-    
+    const targetFamilyId = scope.familyId;
+
     if (id) {
       const baby = await prisma.baby.findFirst({
         where: { 

--- a/app/api/caretaker/route.ts
+++ b/app/api/caretaker/route.ts
@@ -4,6 +4,7 @@ import { ApiResponse, CaretakerCreate, CaretakerUpdate, CaretakerResponse } from
 import { withAuthContext, AuthResult } from '../utils/auth';
 import { checkWritePermission } from '../utils/writeProtection';
 import { toCaretakerResponse } from '../utils/caretaker';
+import { resolveFamilyScope } from '../utils/family-scope';
 
 async function postHandler(req: NextRequest, authContext: AuthResult) {
   // Check write permissions for expired accounts
@@ -13,12 +14,8 @@ async function postHandler(req: NextRequest, authContext: AuthResult) {
   }
 
   try {
-    const { familyId: userFamilyId, caretakerRole, isSysAdmin, isSetupAuth, isAccountAuth } = authContext;
+    const { caretakerRole, isSysAdmin, isSetupAuth, isAccountAuth } = authContext;
 
-    // System administrators, setup auth, and account auth need a family context for caretakers
-    if (!userFamilyId && !isSysAdmin && !isSetupAuth && !isAccountAuth) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
     if (!isSysAdmin && !isSetupAuth && !isAccountAuth && caretakerRole !== 'ADMIN') {
       return NextResponse.json<ApiResponse<null>>({ success: false, error: 'Only admins can create caretakers.' }, { status: 403 });
     }
@@ -27,24 +24,14 @@ async function postHandler(req: NextRequest, authContext: AuthResult) {
     const { familyId: bodyFamilyId, ...caretakerData } = requestBody;
     const body: CaretakerCreate = caretakerData;
 
-    // For system administrators, setup auth, and account auth, require familyId to be passed as query parameter or in body
-    let targetFamilyId = userFamilyId;
-    if (isSysAdmin || isSetupAuth || isAccountAuth) {
-      const { searchParams } = new URL(req.url);
-      const queryFamilyId = searchParams.get('familyId');
-      
-      if (bodyFamilyId) {
-        targetFamilyId = bodyFamilyId;
-      } else if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      } else if (!userFamilyId) {
-        const userType = isSysAdmin ? 'System administrators' : isSetupAuth ? 'Setup authentication' : 'Account authentication';
-        return NextResponse.json<ApiResponse<null>>({ 
-          success: false, 
-          error: `${userType} must specify familyId parameter or in request body.` 
-        }, { status: 400 });
-      }
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
+
+    const scope = resolveFamilyScope(authContext, bodyFamilyId ?? queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
+    const targetFamilyId = scope.familyId;
 
     // Prevent creating system caretaker through API
     if (body.loginId === '00' || body.type === 'System Administrator') {
@@ -120,12 +107,8 @@ async function putHandler(req: NextRequest, authContext: AuthResult) {
   }
 
   try {
-    const { familyId: userFamilyId, caretakerRole, isSysAdmin, isSetupAuth, isAccountAuth } = authContext;
+    const { caretakerRole, isSysAdmin, isSetupAuth, isAccountAuth } = authContext;
 
-    // System administrators, setup auth, and account auth need a family context for caretakers
-    if (!userFamilyId && !isSysAdmin && !isSetupAuth && !isAccountAuth) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
     if (!isSysAdmin && !isSetupAuth && !isAccountAuth && caretakerRole !== 'ADMIN') {
       return NextResponse.json<ApiResponse<null>>({ success: false, error: 'Only admins can update caretakers.' }, { status: 403 });
     }
@@ -141,24 +124,14 @@ async function putHandler(req: NextRequest, authContext: AuthResult) {
       delete updateData.securityPin;
     }
 
-    // For system administrators, setup auth, and account auth, require familyId to be passed as query parameter or in body
-    let targetFamilyId = userFamilyId;
-    if (isSysAdmin || isSetupAuth || isAccountAuth) {
-      const { searchParams } = new URL(req.url);
-      const queryFamilyId = searchParams.get('familyId');
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
 
-      if (bodyFamilyId) {
-        targetFamilyId = bodyFamilyId;
-      } else if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      } else if (!userFamilyId) {
-        const userType = isSysAdmin ? 'System administrators' : isSetupAuth ? 'Setup authentication' : 'Account authentication';
-        return NextResponse.json<ApiResponse<null>>({
-          success: false,
-          error: `${userType} must specify familyId parameter or in request body.`
-        }, { status: 400 });
-      }
+    const scope = resolveFamilyScope(authContext, bodyFamilyId ?? queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
+    const targetFamilyId = scope.familyId;
 
     // Note: System caretaker can be updated (e.g., for PIN changes during setup)
 
@@ -234,34 +207,21 @@ async function deleteHandler(req: NextRequest, authContext: AuthResult) {
   }
 
   try {
-    const { familyId: userFamilyId, caretakerRole, isSysAdmin, isSetupAuth, isAccountAuth } = authContext;
+    const { caretakerRole, isSysAdmin, isSetupAuth, isAccountAuth } = authContext;
 
-    // System administrators, setup auth, and account auth need a family context for caretakers
-    if (!userFamilyId && !isSysAdmin && !isSetupAuth && !isAccountAuth) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
     if (!isSysAdmin && !isSetupAuth && !isAccountAuth && caretakerRole !== 'ADMIN') {
       return NextResponse.json<ApiResponse<null>>({ success: false, error: 'Only admins can delete caretakers.' }, { status: 403 });
     }
 
     const { searchParams } = new URL(req.url);
     const id = searchParams.get('id');
+    const queryFamilyId = searchParams.get('familyId');
 
-    // For system administrators, setup auth, and account auth, require familyId to be passed as query parameter
-    let targetFamilyId = userFamilyId;
-    if (isSysAdmin || isSetupAuth || isAccountAuth) {
-      const queryFamilyId = searchParams.get('familyId');
-
-      if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      } else if (!userFamilyId) {
-        const userType = isSysAdmin ? 'System administrators' : isSetupAuth ? 'Setup authentication' : 'Account authentication';
-        return NextResponse.json<ApiResponse<null>>({
-          success: false,
-          error: `${userType} must specify familyId parameter.`
-        }, { status: 400 });
-      }
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
+    const targetFamilyId = scope.familyId;
 
     if (!id) {
       return NextResponse.json<ApiResponse<null>>({ success: false, error: 'Caretaker ID is required' }, { status: 400 });
@@ -319,7 +279,7 @@ async function deleteHandler(req: NextRequest, authContext: AuthResult) {
 
 async function getHandler(req: NextRequest, authContext: AuthResult) {
   try {
-    const { familyId: userFamilyId, isAccountAuth, caretakerId, accountId, isSysAdmin, isSetupAuth } = authContext;
+    const { familyId: userFamilyId, isAccountAuth, caretakerId, accountId } = authContext;
 
     // Debug logging for account users
     if (isAccountAuth) {
@@ -332,41 +292,15 @@ async function getHandler(req: NextRequest, authContext: AuthResult) {
       });
     }
 
-    // System administrators, setup auth, and account auth need a family context for caretakers
-    if (!userFamilyId && !isSysAdmin && !isSetupAuth && !isAccountAuth) {
-      return NextResponse.json<ApiResponse<null>>({
-        success: false,
-        error: 'User is not associated with a family.'
-      }, { status: 403 });
-    }
-
     const { searchParams } = new URL(req.url);
     const id = searchParams.get('id');
+    const queryFamilyId = searchParams.get('familyId');
 
-    // For system administrators, setup auth, and account auth, require familyId to be passed as query parameter
-    let targetFamilyId = userFamilyId;
-    if (isSysAdmin || isSetupAuth || isAccountAuth) {
-      const queryFamilyId = searchParams.get('familyId');
-
-      if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      } else if (!userFamilyId) {
-        const userType = isSysAdmin ? 'System administrators' : isSetupAuth ? 'Setup authentication' : 'Account authentication';
-        return NextResponse.json<ApiResponse<null>>({
-          success: false,
-          error: `${userType} must specify familyId parameter.`
-        }, { status: 400 });
-      }
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-
-    // Handle incomplete account setup
-    if (!targetFamilyId && isAccountAuth) {
-      console.log('Caretaker API: Account user missing familyId - possible setup incomplete');
-      return NextResponse.json<ApiResponse<null>>({
-        success: false,
-        error: 'Account setup incomplete. Please complete family setup.'
-      }, { status: 403 });
-    }
+    const targetFamilyId = scope.familyId;
 
     if (id) {
       const caretaker = await prisma.caretaker.findFirst({

--- a/app/api/caretaker/system/route.ts
+++ b/app/api/caretaker/system/route.ts
@@ -3,24 +3,18 @@ import prisma from '../../db';
 import { ApiResponse, CaretakerResponse } from '../../types';
 import { withAuthContext, AuthResult } from '../../utils/auth';
 import { toCaretakerResponse } from '../../utils/caretaker';
+import { resolveFamilyScope } from '../../utils/family-scope';
 
 async function getSystemCaretaker(req: NextRequest, authContext: AuthResult) {
   try {
-    const { familyId: userFamilyId, isSetupAuth, isSysAdmin, isAccountAuth } = authContext;
-    
-    // Determine target family ID - prefer auth context, but allow query parameter for setup auth, account auth, and sysadmin
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && (isSetupAuth || isSysAdmin || isAccountAuth)) {
-      const { searchParams } = new URL(req.url);
-      const queryFamilyId = searchParams.get('familyId');
-      if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      }
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
+
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-    
-    if (!targetFamilyId) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
+    const targetFamilyId = scope.familyId;
 
     // Find the system caretaker (loginId '00') for this family
     const systemCaretaker = await prisma.caretaker.findFirst({

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -5,6 +5,7 @@ import { Settings } from '@prisma/client';
 import { withAuthContext, AuthResult } from '../utils/auth';
 import { checkWritePermission } from '../utils/writeProtection';
 import { isValidGrowthStandard } from '@/src/utils/growthStandard';
+import { resolveFamilyScope } from '../utils/family-scope';
 
 // The family securityPin (login PIN) must never be returned to the client.
 type SettingsResponse = Omit<Settings, 'securityPin'>;
@@ -14,21 +15,14 @@ function toSettingsResponse({ securityPin: _securityPin, ...rest }: Settings): S
 
 async function handleGet(req: NextRequest, authContext: AuthResult) {
   try {
-    const { familyId: userFamilyId, isSetupAuth, isSysAdmin, isAccountAuth } = authContext;
-    
-    // Determine target family ID - prefer auth context, but allow query parameter for setup auth, account auth, and sysadmin
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && (isSetupAuth || isSysAdmin || isAccountAuth)) {
-      const { searchParams } = new URL(req.url);
-      const queryFamilyId = searchParams.get('familyId');
-      if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      }
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
+
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-    
-    if (!targetFamilyId) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
+    const targetFamilyId = scope.familyId;
 
     let settings = await prisma.settings.findFirst({
       where: { familyId: targetFamilyId },
@@ -76,21 +70,14 @@ async function handlePut(req: NextRequest, authContext: AuthResult) {
   }
 
   try {
-    const { familyId: userFamilyId, isSetupAuth, isSysAdmin, isAccountAuth } = authContext;
-    
-    // Determine target family ID - prefer auth context, but allow query parameter for setup auth, account auth, and sysadmin
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && (isSetupAuth || isSysAdmin || isAccountAuth)) {
-      const { searchParams } = new URL(req.url);
-      const queryFamilyId = searchParams.get('familyId');
-      if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      }
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
+
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
+      return NextResponse.json<ApiResponse<null>>({ success: false, error: scope.error }, { status: scope.status });
     }
-    
-    if (!targetFamilyId) {
-      return NextResponse.json<ApiResponse<null>>({ success: false, error: 'User is not associated with a family.' }, { status: 403 });
-    }
+    const targetFamilyId = scope.familyId;
 
     const body = await req.json();
     

--- a/app/api/settings/verify-pin/route.ts
+++ b/app/api/settings/verify-pin/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import prisma from '../../db';
 import { ApiResponse } from '../../types';
 import { withAuthContext, AuthResult } from '../../utils/auth';
+import { resolveFamilyScope } from '../../utils/family-scope';
 
 /**
  * POST /api/settings/verify-pin
@@ -16,23 +17,17 @@ async function handler(
   authContext: AuthResult
 ): Promise<NextResponse<ApiResponse<{ valid: boolean }>>> {
   try {
-    const { familyId: userFamilyId, isSetupAuth, isSysAdmin, isAccountAuth } = authContext;
+    const { searchParams } = new URL(req.url);
+    const queryFamilyId = searchParams.get('familyId');
 
-    let targetFamilyId = userFamilyId;
-    if (!userFamilyId && (isSetupAuth || isSysAdmin || isAccountAuth)) {
-      const { searchParams } = new URL(req.url);
-      const queryFamilyId = searchParams.get('familyId');
-      if (queryFamilyId) {
-        targetFamilyId = queryFamilyId;
-      }
-    }
-
-    if (!targetFamilyId) {
+    const scope = resolveFamilyScope(authContext, queryFamilyId);
+    if (!scope.ok) {
       return NextResponse.json<ApiResponse<{ valid: boolean }>>(
-        { success: false, error: 'User is not associated with a family.' },
-        { status: 403 }
+        { success: false, error: scope.error },
+        { status: scope.status }
       );
     }
+    const targetFamilyId = scope.familyId;
 
     const body = await req.json().catch(() => ({}));
     const pin = typeof body?.pin === 'string' ? body.pin : '';

--- a/app/api/utils/family-scope.ts
+++ b/app/api/utils/family-scope.ts
@@ -1,0 +1,36 @@
+export interface FamilyScopeAuth {
+  familyId?: string | null;
+  isSysAdmin?: boolean;
+}
+
+export type FamilyScopeResult =
+  | { ok: true; familyId: string }
+  | { ok: false; status: 400 | 403; error: string };
+
+/**
+ * Resolves the family an authenticated request may act on, enforcing the golden
+ * rule that only sysadmins act across families.
+ *
+ * `auth.familyId` is the authority: withAuthContext resolves it from the account
+ * (live), the caretaker row, or a validated setup token before any handler runs.
+ * A client-supplied `requestedFamilyId` may only CONFIRM it, never override it.
+ */
+export function resolveFamilyScope(
+  auth: FamilyScopeAuth,
+  requestedFamilyId: string | null | undefined,
+): FamilyScopeResult {
+  if (auth.isSysAdmin) {
+    const target = requestedFamilyId ?? auth.familyId ?? null;
+    if (!target) {
+      return { ok: false, status: 400, error: 'System administrators must specify a familyId.' };
+    }
+    return { ok: true, familyId: target };
+  }
+  if (!auth.familyId) {
+    return { ok: false, status: 403, error: 'User is not associated with a family.' };
+  }
+  if (requestedFamilyId && requestedFamilyId !== auth.familyId) {
+    return { ok: false, status: 403, error: 'Not authorized for this family.' };
+  }
+  return { ok: true, familyId: auth.familyId };
+}

--- a/tests/family-scope.test.ts
+++ b/tests/family-scope.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFamilyScope } from '@/app/api/utils/family-scope';
+
+describe('resolveFamilyScope', () => {
+  describe('account/caretaker with a family', () => {
+    it('no requested id -> ok with the auth family', () => {
+      const result = resolveFamilyScope({ familyId: 'A' }, null);
+      expect(result).toEqual({ ok: true, familyId: 'A' });
+    });
+
+    it('requested id matches auth family -> ok (shell/web happy path)', () => {
+      const result = resolveFamilyScope({ familyId: 'A' }, 'A');
+      expect(result).toEqual({ ok: true, familyId: 'A' });
+    });
+
+    it('requested id mismatches auth family -> 403 (the exploit, blocked)', () => {
+      const result = resolveFamilyScope({ familyId: 'A' }, 'B');
+      expect(result).toEqual({
+        ok: false,
+        status: 403,
+        error: 'Not authorized for this family.',
+      });
+    });
+  });
+
+  describe('account/caretaker with no family', () => {
+    it('mismatched requested id -> 403 (no-family exploit blocked)', () => {
+      const result = resolveFamilyScope({ familyId: null }, 'B');
+      expect(result).toEqual({
+        ok: false,
+        status: 403,
+        error: 'User is not associated with a family.',
+      });
+    });
+
+    it('no requested id -> 403', () => {
+      const result = resolveFamilyScope({ familyId: null }, null);
+      expect(result).toEqual({
+        ok: false,
+        status: 403,
+        error: 'User is not associated with a family.',
+      });
+    });
+  });
+
+  describe('sysadmin', () => {
+    it('requested id -> ok with the requested family (cross-family preserved)', () => {
+      const result = resolveFamilyScope({ familyId: 'A', isSysAdmin: true }, 'B');
+      expect(result).toEqual({ ok: true, familyId: 'B' });
+    });
+
+    it('no requested id but context has a family -> ok with the context family', () => {
+      const result = resolveFamilyScope({ familyId: 'A', isSysAdmin: true }, null);
+      expect(result).toEqual({ ok: true, familyId: 'A' });
+    });
+
+    it('neither requested id nor context family -> 400', () => {
+      const result = resolveFamilyScope({ familyId: null, isSysAdmin: true }, null);
+      expect(result).toEqual({
+        ok: false,
+        status: 400,
+        error: 'System administrators must specify a familyId.',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Hardens family-level authorization on several API routes. Client-supplied family context is now validated server-side against the authenticated context via a shared, unit-tested policy helper (`app/api/utils/family-scope.ts`) applied consistently across the affected routes. Sysadmin cross-family administration is preserved.

## Compatibility

- Existing web/mobile flows are unaffected (setup wizard, invite flow, and family-manager console all verified).
- The only behavior change is an error-path status/message shift on some invalid requests.

## Tests

`tests/family-scope.test.ts` (8 cases) covering allowed and denied paths. Full suite green, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)