### PR TITLE
chore: whitelist WHO CSV files in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,3 +61,6 @@ documentation/
 !documentation/wtageinf.csv
 !documentation/hcageinf.csv
 !documentation/lenageinf.csv
+!documentation/who-wtageinf.csv
+!documentation/who-hcageinf.csv
+!documentation/who-lenageinf.csv


### PR DESCRIPTION
Fixes https://github.com/Oak-and-Sprout/sprout-track/issues/242 - Adds `who-wtageinf.csv`, `who-hcageinf.csv`, and `who-lenageinf.csv` to the .dockerignore whitelist so they are included in Docker builds.