### PR TITLE
fix(breastfeed): nursing session rows stamped with session end time (#240)

### DIFF
--- a/app/api/utils/activeBreastFeed.ts
+++ b/app/api/utils/activeBreastFeed.ts
@@ -191,7 +191,10 @@ export async function endBreastfeedSession(session: ActiveBreastFeed, opts: EndS
     const log = await prisma.feedLog.create({
       data: {
         babyId: session.babyId,
-        time: now,
+        // Each side's `time` is its own start: the linked-session list shows
+        // `time`, and the edit form writes startTime back into `time` on
+        // update, so a session-end stamp here would disagree with both (#240)
+        time: block.startTime,
         type: 'BREAST',
         side: block.side,
         startTime: block.startTime,

--- a/src/components/forms/FeedForm/LinkedFeedsSection.tsx
+++ b/src/components/forms/FeedForm/LinkedFeedsSection.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/src/components/ui/toast';
 import {
   groupBreastFeedSessions,
   newFeedSessionId,
+  breastFeedDisplayTime,
   BreastFeedSession,
 } from '@/src/utils/feedSessionUtils';
 
@@ -145,7 +146,7 @@ export default function LinkedFeedsSection({
     const side = feed.side === 'LEFT' ? t('Left Side') : feed.side === 'RIGHT' ? t('Right Side') : t('Breast');
     const seconds = feed.feedDuration || (feed.amount ? feed.amount * 60 : 0);
     const minutes = Math.round(seconds / 60);
-    return `${side} • ${minutes} ${t('min')} • ${formatDateTime(feed.time)}`;
+    return `${side} • ${minutes} ${t('min')} • ${formatDateTime(breastFeedDisplayTime(feed))}`;
   };
 
   const renderRow = (feed: FeedLogResponse, linked: boolean) => (

--- a/src/utils/feedSessionUtils.ts
+++ b/src/utils/feedSessionUtils.ts
@@ -152,6 +152,19 @@ export function newFeedSessionId(): string {
 }
 
 /**
+ * Timestamp to display for a breast feed row: the side's start when known.
+ * Rows created by the timer before v1.6.3 stamp `time` with the session end,
+ * so `time` alone is only trustworthy as a fallback (issue #240).
+ */
+export function breastFeedDisplayTime(row: {
+  time: string | Date;
+  startTime?: string | Date | null;
+}): string {
+  const value = row.startTime ?? row.time;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+/**
  * Number of nursing sessions represented by the given feed logs
  * (linked or paired rows count once; non-BREAST rows are ignored).
  */

--- a/tests/activeBreastFeed.test.ts
+++ b/tests/activeBreastFeed.test.ts
@@ -1,24 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createSession } = vi.hoisted(() => ({
+const { createSession, deleteSession, createFeedLog } = vi.hoisted(() => ({
   createSession: vi.fn(),
+  deleteSession: vi.fn(),
+  createFeedLog: vi.fn(),
 }));
 
 vi.mock('@/app/api/db', () => ({
   default: {
     activeBreastFeed: {
       create: createSession,
+      delete: deleteSession,
+    },
+    feedLog: {
+      create: createFeedLog,
     },
   },
 }));
 
 vi.mock('@/src/lib/notifications/activityHook', () => ({
-  notifyActivityCreated: vi.fn(),
-  resetTimerNotificationState: vi.fn(),
+  notifyActivityCreated: vi.fn().mockResolvedValue(undefined),
+  resetTimerNotificationState: vi.fn().mockResolvedValue(undefined),
 }));
 
 import {
   startBreastfeedSession,
+  endBreastfeedSession,
   resolveRequestedStartTime,
   START_TIME_CLOCK_SKEW_MS,
 } from '@/app/api/utils/activeBreastFeed';
@@ -44,6 +51,82 @@ describe('startBreastfeedSession', () => {
         sessionStartTime: requestedStartTime,
       }),
     });
+  });
+});
+
+// Issue #240: each row's `time` must be its own side's start time, not the
+// moment the session ended — the linked-session list displays `time`, and
+// re-saving from the edit form writes startTime into `time`, so a session-end
+// stamp made the two paths disagree.
+describe('endBreastfeedSession', () => {
+  beforeEach(() => {
+    let nextId = 0;
+    createFeedLog.mockReset();
+    createFeedLog.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: `log-${++nextId}`,
+      ...data,
+    }));
+    deleteSession.mockReset();
+    deleteSession.mockResolvedValue({});
+  });
+
+  it('stamps each FeedLog time with that side\'s start time', async () => {
+    const sessionStartTime = new Date('2026-07-22T12:00:00.000Z');
+    const session = {
+      id: 'session-1',
+      babyId: 'baby-1',
+      activeSide: 'RIGHT',
+      isPaused: false,
+      leftDuration: 120,
+      rightDuration: 60,
+      pauseDuration: 30,
+      pausedAt: null,
+      firstSide: 'LEFT',
+      currentSideStartTime: null,
+      sessionStartTime,
+      familyId: 'family-1',
+      caretakerId: 'caretaker-1',
+    };
+
+    await endBreastfeedSession(session as any, { familyId: 'family-1' });
+
+    expect(createFeedLog).toHaveBeenCalledTimes(2);
+    const rows = createFeedLog.mock.calls.map(([arg]) => arg.data);
+    const left = rows.find(r => r.side === 'LEFT')!;
+    const right = rows.find(r => r.side === 'RIGHT')!;
+
+    // First side starts at the session start; second side starts after the
+    // first side's duration plus the pause gap.
+    expect(left.time).toEqual(sessionStartTime);
+    expect(left.time).toEqual(left.startTime);
+    expect(right.time).toEqual(new Date('2026-07-22T12:02:30.000Z'));
+    expect(right.time).toEqual(right.startTime);
+  });
+
+  it('stamps a single-side session with the session start time', async () => {
+    const sessionStartTime = new Date('2026-07-22T08:00:00.000Z');
+    const session = {
+      id: 'session-2',
+      babyId: 'baby-1',
+      activeSide: 'LEFT',
+      isPaused: false,
+      leftDuration: 300,
+      rightDuration: 0,
+      pauseDuration: 0,
+      pausedAt: null,
+      firstSide: 'LEFT',
+      currentSideStartTime: null,
+      sessionStartTime,
+      familyId: 'family-1',
+      caretakerId: null,
+    };
+
+    await endBreastfeedSession(session as any, { familyId: 'family-1' });
+
+    expect(createFeedLog).toHaveBeenCalledTimes(1);
+    const [{ data }] = createFeedLog.mock.calls[0];
+    expect(data.time).toEqual(sessionStartTime);
+    expect(data.time).toEqual(data.startTime);
   });
 });
 

--- a/tests/feedSessionUtils.test.ts
+++ b/tests/feedSessionUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   groupBreastFeedSessions,
   countBreastFeedSessions,
+  breastFeedDisplayTime,
 } from '@/src/utils/feedSessionUtils';
 
 // Issue #198: a nursing session using both sides is stored as two FeedLog rows
@@ -180,5 +181,37 @@ describe('explicit sessionId linking', () => {
     const sessions = groupBreastFeedSessions(rows);
     expect(sessions[0].sessionId).toBe('早');
     expect(sessions[1].sessionId).toBeNull();
+  });
+});
+
+// Issue #240: rows created by the timer before the fix stamp `time` with the
+// session end; displays must prefer startTime so those legacy rows still show
+// the side's actual start.
+describe('breastFeedDisplayTime', () => {
+  it('prefers startTime when present', () => {
+    expect(
+      breastFeedDisplayTime({
+        time: '2026-07-22T13:02:00.000Z',
+        startTime: '2026-07-22T13:00:00.000Z',
+      })
+    ).toBe('2026-07-22T13:00:00.000Z');
+  });
+
+  it('falls back to time when startTime is missing or null', () => {
+    expect(breastFeedDisplayTime({ time: '2026-07-22T13:02:00.000Z' })).toBe(
+      '2026-07-22T13:02:00.000Z'
+    );
+    expect(
+      breastFeedDisplayTime({ time: '2026-07-22T13:02:00.000Z', startTime: null })
+    ).toBe('2026-07-22T13:02:00.000Z');
+  });
+
+  it('serializes Date values to ISO strings', () => {
+    expect(
+      breastFeedDisplayTime({
+        time: '2026-07-22T13:02:00.000Z',
+        startTime: new Date('2026-07-22T13:00:00.000Z'),
+      })
+    ).toBe('2026-07-22T13:00:00.000Z');
   });
 });


### PR DESCRIPTION
Fixes #240.

## Root cause

`endBreastfeedSession` lays out correct per-side `startTime`/`endTime` blocks, but stamped `time: now` (the session-end moment) on **both** FeedLog rows. The timeline and record details look right because they prefer `startTime` for breast feeds, but the Nursing Session linked-feeds list displays `time` — so both sides showed the session end. Re-saving an entry "corrected" it because the edit form initializes its time field from `startTime` and writes that back into `time` on update.

## Fix

- `endBreastfeedSession` now stamps each row's `time` with its own side block's start, matching what the edit path produces.
- New pure helper `breastFeedDisplayTime` (prefer `startTime`, fall back to `time`), used by `LinkedFeedsSection` — consistent with `getActivityTime`/`getActivityDetails`, and it makes **existing** rows stamped with the session end render correctly with no data migration. All three detail surfaces (timeline, full log, edit form) share this component.

## Tests

5 new tests (`endBreastfeedSession` time stamping for dual- and single-side sessions; `breastFeedDisplayTime` fallback behavior). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqUNSVENoZGYNyBH3iFgaZ