### PR TITLE
Improve growth chart Y-axis scale and latest measurement guide

### DIFF
--- a/src/components/Reports/GrowthChart.tsx
+++ b/src/components/Reports/GrowthChart.tsx
@@ -9,6 +9,7 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  ReferenceLine,
 } from 'recharts';
 import { Scale, Ruler, CircleDot, Loader2, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { cn } from '@/src/lib/utils';
@@ -19,6 +20,10 @@ import { useTimezone } from '@/app/context/timezone';
 import { formatDateLong } from '@/src/utils/dateFormat';
 import { toCdcWeightKg, fromCdcWeightKg, weightUnitLabel, formatChartValue } from '@/src/utils/weightUnits';
 import { effectiveGrowthStandard } from '@/src/utils/growthStandard';
+import {
+  buildGrowthChartYAxis,
+  formatGrowthChartAxisTick,
+} from '@/src/utils/growthChartAxis';
 
 // Types
 export type GrowthMeasurementType = 'weight' | 'length' | 'head_circumference';
@@ -713,15 +718,11 @@ const GrowthChart: React.FC<GrowthChartProps> = ({ className }) => {
     return mergedData.sort((a, b) => a.ageMonths - b.ageMonths);
   }, [cdcData, measurementsWithPercentiles, measurementType, selectedBaby, settings, babyCurrentAgeMonths]);
 
-  // Dynamic Y-axis domain based on visible data (min - 10%, max + 10%)
-  const yAxisDomain = useMemo(() => {
-    if (!chartData.length) return ['auto', 'auto'] as const;
+  const unitLabel = getUnitLabel(measurementType, settings);
 
-    let min = Number.POSITIVE_INFINITY;
-    let max = Number.NEGATIVE_INFINITY;
-
-    chartData.forEach((point) => {
-      const values = [
+  const yAxis = useMemo(
+    () => buildGrowthChartYAxis(
+      chartData.flatMap(point => [
         point.p3,
         point.p5,
         point.p10,
@@ -732,28 +733,13 @@ const GrowthChart: React.FC<GrowthChartProps> = ({ className }) => {
         point.p95,
         point.p97,
         point.measurement,
-      ].filter((v): v is number => typeof v === 'number' && !Number.isNaN(v));
+      ]),
+      unitLabel,
+    ),
+    [chartData, unitLabel],
+  );
 
-      values.forEach((v) => {
-        if (v < min) min = v;
-        if (v > max) max = v;
-      });
-    });
-
-    if (!Number.isFinite(min) || !Number.isFinite(max)) {
-      return ['auto', 'auto'] as const;
-    }
-
-    const range = max - min;
-    const padding = range > 0 ? range * 0.1 : (max || 1) * 0.1;
-    let lower = min - padding;
-    const upper = max + padding;
-
-    // Don't go below zero for growth metrics
-    if (lower < 0) lower = 0;
-
-    return [lower, upper] as const;
-  }, [chartData]);
+  const latestMeasurement = measurementsWithPercentiles.at(-1);
 
   // Zoom handlers
   const handleZoomIn = useCallback(() => {
@@ -878,8 +864,6 @@ const GrowthChart: React.FC<GrowthChartProps> = ({ className }) => {
     );
   }
 
-  const unitLabel = getUnitLabel(measurementType, settings);
-
   return (
     <div className={cn(growthChartStyles.container, "growth-chart-container", className)}>
       {/* Top controls row: measurement type buttons (left) and zoom controls (right) */}
@@ -972,12 +956,28 @@ const GrowthChart: React.FC<GrowthChartProps> = ({ className }) => {
               />
               <YAxis
                 type="number"
-                domain={yAxisDomain as any}
-                tickFormatter={(value) => Number(value).toFixed(0)}
+                domain={yAxis.domain}
+                ticks={yAxis.ticks}
+                tickFormatter={(value) => formatGrowthChartAxisTick(Number(value), yAxis.step, unitLabel)}
                 label={{ value: unitLabel, angle: -90, position: 'insideLeft', offset: 18 }}
                 className="growth-chart-axis"
               />
               <Tooltip content={<CustomTooltip settings={settings} measurementType={measurementType} t={t} />} />
+
+              {latestMeasurement && (
+                <ReferenceLine
+                  y={latestMeasurement.displayValue}
+                  stroke="#f97316"
+                  strokeWidth={1.5}
+                  strokeDasharray="6 4"
+                  label={{
+                    value: `${t('Last Entry')}: ${formatChartValue(latestMeasurement.displayValue, unitLabel)} ${unitLabel}`,
+                    position: 'insideTopRight',
+                    fill: '#c2410c',
+                    fontSize: 12,
+                  }}
+                />
+              )}
 
               {/* Percentile lines - using gradient from light to dark */}
               <Line

--- a/src/components/Reports/MonthlyReportCard/GrowthSummarySection.tsx
+++ b/src/components/Reports/MonthlyReportCard/GrowthSummarySection.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo } from 'react';
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine,
 } from 'recharts';
 import { Scale, Ruler, CircleDot } from 'lucide-react';
 import { cn } from '@/src/lib/utils';
@@ -11,6 +11,10 @@ import { reportCardStyles as s } from './monthly-report-card.styles';
 import type { GrowthSummarySectionProps } from './monthly-report-card.types';
 import type { GrowthMetric, GrowthChartData } from '@/app/api/types';
 import { formatChartValue } from '@/src/utils/weightUnits';
+import {
+  buildGrowthChartYAxis,
+  formatGrowthChartAxisTick,
+} from '@/src/utils/growthChartAxis';
 
 type ChartType = 'weight' | 'length' | 'headCircumference';
 
@@ -159,16 +163,19 @@ function GrowthChartCard({
     );
   }
 
-  // Compute Y domain with padding
   const allValues = chartData.points.flatMap(p => [
-    p.p3, p.p97, ...(p.measurement !== undefined ? [p.measurement] : []),
+    p.p3,
+    p.p10,
+    p.p25,
+    p.p50,
+    p.p75,
+    p.p90,
+    p.p97,
+    p.measurement,
   ]);
-  const min = Math.min(...allValues);
-  const max = Math.max(...allValues);
-  const range = max - min;
-  const padding = range > 0 ? range * 0.1 : (max || 1) * 0.1;
-  const yMin = Math.max(0, min - padding);
-  const yMax = max + padding;
+  const unit = chartData.unit || '';
+  const yAxis = buildGrowthChartYAxis(allValues, unit);
+  const latestMeasurement = chartData.points.findLast(point => point.measurement !== undefined);
 
   return (
     <div className={cn(s.card, 'report-card-card report-card-chart')}>
@@ -185,10 +192,26 @@ function GrowthChartCard({
             />
             <YAxis
               tick={{ fontSize: 11 }}
-              domain={[yMin, yMax]}
-              tickFormatter={(v: number) => Number(v).toFixed(0)}
+              domain={yAxis.domain}
+              ticks={yAxis.ticks}
+              tickFormatter={(value: number) => formatGrowthChartAxisTick(value, yAxis.step, unit)}
             />
-            <Tooltip content={<GrowthChartTooltip babyName={babyName} unit={chartData.unit} t={t} />} />
+            <Tooltip content={<GrowthChartTooltip babyName={babyName} unit={unit} t={t} />} />
+
+            {latestMeasurement?.measurement !== undefined && (
+              <ReferenceLine
+                y={latestMeasurement.measurement}
+                stroke="#f97316"
+                strokeWidth={1.25}
+                strokeDasharray="6 4"
+                label={{
+                  value: `${t('Last Entry')}: ${formatChartValue(latestMeasurement.measurement, unit)} ${unit}`,
+                  position: 'insideTopRight',
+                  fill: '#c2410c',
+                  fontSize: 10,
+                }}
+              />
+            )}
 
             {/* Percentile curves */}
             {percentileLines.map(line => (

--- a/src/utils/growthChartAxis.ts
+++ b/src/utils/growthChartAxis.ts
@@ -1,0 +1,123 @@
+export interface GrowthChartYAxis {
+  domain: [number, number];
+  ticks: number[];
+  step: number;
+}
+
+const NICE_MULTIPLIERS = [1, 2, 2.5, 5, 10] as const;
+const DEFAULT_MAX_INTERVALS = 7;
+
+function normalizeUnit(unit: string): string {
+  return unit.trim().toLowerCase();
+}
+
+function minimumStepForUnit(unit: string): number {
+  switch (normalizeUnit(unit)) {
+    case 'g':
+      return 50;
+    case 'kg':
+      return 0.25;
+    case 'lb':
+    case 'in':
+      return 0.5;
+    case 'cm':
+      return 1;
+    default:
+      return 0.1;
+  }
+}
+
+function niceStepAtLeast(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 1;
+
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const normalized = value / magnitude;
+  const multiplier = NICE_MULTIPLIERS.find(candidate => candidate >= normalized) ?? 10;
+
+  return multiplier * magnitude;
+}
+
+function nextNiceStep(step: number): number {
+  return niceStepAtLeast(step * (1 + Number.EPSILON * 16));
+}
+
+function roundFloatingPoint(value: number): number {
+  return Number(value.toPrecision(12));
+}
+
+function roundedDomain(min: number, max: number, step: number): [number, number] {
+  const lower = Math.max(0, Math.floor(min / step) * step);
+  const upper = Math.ceil(max / step) * step;
+  return [roundFloatingPoint(lower), roundFloatingPoint(upper)];
+}
+
+function buildTicks(domain: [number, number], step: number): number[] {
+  const intervalCount = Math.round((domain[1] - domain[0]) / step);
+  return Array.from(
+    { length: intervalCount + 1 },
+    (_, index) => roundFloatingPoint(domain[0] + index * step),
+  );
+}
+
+/**
+ * Builds a deterministic Y-axis that contains every supplied growth value.
+ * The domain is rounded outwards and ticks use evenly spaced, human-friendly
+ * intervals such as 500 g, 1 kg, 2 cm, or 0.5 in.
+ */
+export function buildGrowthChartYAxis(
+  values: readonly (number | null | undefined)[],
+  unit: string,
+  maxIntervals = DEFAULT_MAX_INTERVALS,
+): GrowthChartYAxis {
+  const finiteValues = values.filter(
+    (value): value is number => typeof value === 'number' && Number.isFinite(value),
+  );
+  const minimumStep = minimumStepForUnit(unit);
+
+  if (!finiteValues.length) {
+    const domain: [number, number] = [0, minimumStep * 5];
+    return {
+      domain,
+      ticks: buildTicks(domain, minimumStep),
+      step: minimumStep,
+    };
+  }
+
+  let min = Math.min(...finiteValues);
+  let max = Math.max(...finiteValues);
+
+  if (min === max) {
+    const halfSpan = Math.max(Math.abs(min) * 0.1, minimumStep);
+    min = Math.max(0, min - halfSpan);
+    max += halfSpan;
+  }
+
+  const safeMaxIntervals = Math.max(2, Math.floor(maxIntervals));
+  let step = Math.max(minimumStep, niceStepAtLeast((max - min) / safeMaxIntervals));
+  let domain = roundedDomain(min, max, step);
+
+  while ((domain[1] - domain[0]) / step > safeMaxIntervals) {
+    step = nextNiceStep(step);
+    domain = roundedDomain(min, max, step);
+  }
+
+  return {
+    domain,
+    ticks: buildTicks(domain, step),
+    step: roundFloatingPoint(step),
+  };
+}
+
+export function formatGrowthChartAxisTick(value: number, step: number, unit: string): string {
+  if (normalizeUnit(unit) === 'g') return String(Math.round(value));
+
+  let decimalPlaces = 0;
+  while (
+    decimalPlaces < 4
+    && Math.abs(step * 10 ** decimalPlaces - Math.round(step * 10 ** decimalPlaces)) > 1e-9
+  ) {
+    decimalPlaces += 1;
+  }
+
+  return value.toFixed(decimalPlaces);
+}

--- a/tests/growthChartAxis.test.ts
+++ b/tests/growthChartAxis.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGrowthChartYAxis,
+  formatGrowthChartAxisTick,
+} from '@/src/utils/growthChartAxis';
+
+describe('buildGrowthChartYAxis', () => {
+  it('uses 500 g ticks for a focused infant weight range', () => {
+    expect(buildGrowthChartYAxis([3180, 4355, 4870], 'g')).toEqual({
+      domain: [3000, 5000],
+      ticks: [3000, 3500, 4000, 4500, 5000],
+      step: 500,
+    });
+  });
+
+  it('uses wider gram intervals when the full visible range needs them', () => {
+    expect(buildGrowthChartYAxis([2507, 4355, 7917], 'g')).toEqual({
+      domain: [2000, 8000],
+      ticks: [2000, 3000, 4000, 5000, 6000, 7000, 8000],
+      step: 1000,
+    });
+  });
+
+  it('keeps a larger kilogram history readable without clipping values', () => {
+    const scale = buildGrowthChartYAxis([2.5, 12, 15], 'kg');
+
+    expect(scale).toEqual({
+      domain: [2, 16],
+      ticks: [2, 4, 6, 8, 10, 12, 14, 16],
+      step: 2,
+    });
+    expect(scale.domain[0]).toBeLessThanOrEqual(2.5);
+    expect(scale.domain[1]).toBeGreaterThanOrEqual(15);
+  });
+
+  it('uses proportional steps for centimetres and inches', () => {
+    expect(buildGrowthChartYAxis([48.2, 56.9], 'cm')).toEqual({
+      domain: [48, 58],
+      ticks: [48, 50, 52, 54, 56, 58],
+      step: 2,
+    });
+    expect(buildGrowthChartYAxis([19.1, 22.4], 'in')).toEqual({
+      domain: [19, 22.5],
+      ticks: [19, 19.5, 20, 20.5, 21, 21.5, 22, 22.5],
+      step: 0.5,
+    });
+  });
+
+  it('returns a stable fallback for empty data', () => {
+    expect(buildGrowthChartYAxis([], 'g')).toEqual({
+      domain: [0, 250],
+      ticks: [0, 50, 100, 150, 200, 250],
+      step: 50,
+    });
+  });
+
+  it('expands a single value into a non-zero domain', () => {
+    const scale = buildGrowthChartYAxis([4.355], 'kg');
+
+    expect(scale.domain[0]).toBeLessThan(4.355);
+    expect(scale.domain[1]).toBeGreaterThan(4.355);
+    expect(scale.ticks.length).toBeGreaterThan(1);
+  });
+});
+
+describe('formatGrowthChartAxisTick', () => {
+  it('formats grams as whole numbers', () => {
+    expect(formatGrowthChartAxisTick(4355, 500, 'g')).toBe('4355');
+  });
+
+  it('preserves decimals required by the selected step', () => {
+    expect(formatGrowthChartAxisTick(4.5, 0.5, 'kg')).toBe('4.5');
+    expect(formatGrowthChartAxisTick(4.25, 0.25, 'kg')).toBe('4.25');
+    expect(formatGrowthChartAxisTick(12, 2, 'kg')).toBe('12');
+  });
+});


### PR DESCRIPTION
## What changed

- replace automatically generated growth-chart Y-axis labels with deterministic, evenly spaced ticks
- round the visible domain outwards so all CDC/WHO percentile curves and recorded measurements remain visible
- adapt tick intervals to the configured unit and visible range
- add a labelled horizontal guide for the latest measurement
- share the same scale behavior between the main growth chart and monthly report charts
- add unit coverage for grams, kilograms, centimetres, inches, empty data, and larger historical ranges

## Why

The previous domain used raw 10% padding and delegated tick selection to Recharts. The resulting labels could appear arbitrary, especially for gram values, even though the underlying CDC/WHO data was correct.

The new scale changes only presentation. Percentile calculations and official curve values are unchanged.

Fixes #256

## Validation

- `npm test -- tests/growthChartAxis.test.ts` — 8 tests passed
- `DATABASE_URL=file:/private/tmp/sprout-track-growth-axis-test.db npm test` — 91 files and 1139 tests passed
- `npx tsc --noEmit` — passed
- production compilation completed successfully with webpack; the subsequent route validation is blocked by an unrelated existing invalid export in `app/api/food/merge/route.ts`
