### PR TITLE
fix(prisma): keep generated clients external so one image serves Postgres + SQLite (#266)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,42 @@
+import type { NextConfig } from 'next';
+
+/**
+ * Keep the Prisma client and its driver adapters out of the Next/Turbopack
+ * server bundle so they are `require`d from `node_modules` at runtime.
+ *
+ * Why this matters (issue #266): Prisma requires a *literal* datasource
+ * `provider` in schema.prisma, so the provider ("sqlite" | "postgresql") is
+ * frozen into the generated client at `prisma generate` time — it cannot come
+ * from an env var. The Docker image runs `prisma generate` at build time with
+ * the default sqlite provider, then `next build`. Without this config,
+ * Turbopack inlines that sqlite-generated client into `.next/server/chunks`.
+ *
+ * At container startup `docker-startup.sh` rewrites the schema to the runtime
+ * DATABASE_PROVIDER and re-runs `prisma generate`, which correctly updates
+ * `node_modules/.prisma/client` to postgresql — but a bundled copy would be
+ * ignored, so a PostgreSQL deployment loaded the stale sqlite client and threw
+ * `PrismaClientInitializationError: The Driver Adapter @prisma/adapter-pg ...
+ * is not compatible with the provider sqlite specified in the Prisma schema.`
+ *
+ * Marking these packages external makes the runtime-regenerated client the one
+ * that actually loads, so a single image serves both sqlite and postgresql.
+ */
+const nextConfig: NextConfig = {
+  serverExternalPackages: [
+    // The main client is imported as `@prisma/client`; the log client is
+    // generated to a custom output and imported directly as `.prisma/log-client`
+    // (see prisma/log-db.ts). BOTH must be external or Turbopack inlines the
+    // generated client — including its build-time `activeProvider` — into the
+    // server bundle, defeating the runtime `prisma generate` in docker-startup.sh.
+    // Turbopack matches these by import specifier, not the generated package's
+    // hashed name, so list the specifiers exactly as imported.
+    '@prisma/client',
+    '.prisma/client',
+    '.prisma/log-client',
+    '@prisma/adapter-pg',
+    '@prisma/adapter-better-sqlite3',
+    'better-sqlite3',
+  ],
+};
+
+export default nextConfig;

--- a/tests/next-config-prisma-external.test.ts
+++ b/tests/next-config-prisma-external.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import nextConfig from '@/next.config';
+
+/**
+ * Regression guard for issue #266.
+ *
+ * The single Docker image generates the Prisma client for sqlite at build time,
+ * then rewrites the provider and regenerates at container startup. That runtime
+ * regeneration only takes effect if the Prisma client is loaded from
+ * node_modules at runtime instead of being inlined into the Next/Turbopack
+ * server bundle. `serverExternalPackages` is what keeps it external — dropping
+ * these entries silently reintroduces the sqlite-vs-postgresql mismatch.
+ */
+describe('next.config serverExternalPackages (issue #266)', () => {
+  const external = nextConfig.serverExternalPackages ?? [];
+
+  it('keeps the Prisma client external so the runtime-regenerated client loads', () => {
+    expect(external).toContain('@prisma/client');
+    expect(external).toContain('.prisma/client');
+  });
+
+  it('keeps the separately-generated log client external', () => {
+    // prisma/log-db.ts imports `.prisma/log-client` (custom generator output).
+    // Missing this entry leaves the log client bundled with a stale provider,
+    // so every API route that logs a request throws PrismaClientInitializationError.
+    expect(external).toContain('.prisma/log-client');
+  });
+
+  it('keeps both driver adapters external', () => {
+    expect(external).toContain('@prisma/adapter-pg');
+    expect(external).toContain('@prisma/adapter-better-sqlite3');
+  });
+});


### PR DESCRIPTION
## Problem (fixes #266)

PostgreSQL deployments of **1.6.6** crash on first DB-touching request:

> `PrismaClientInitializationError: The Driver Adapter @prisma/adapter-pg, based on postgres, is not compatible with the provider sqlite specified in the Prisma schema.`

This blocks the UI and login; rolling back to 1.6.5 was the only workaround.

## Root cause

A regression from the 1.6.6 dependency jump (Next 15→16 + Prisma 6→7):

- **Prisma 7** strictly checks that the driver adapter matches the `activeProvider` baked into the **generated client**.
- The image runs `prisma generate` at **build time** with the default `sqlite` provider, then `next build`. With **no `next.config`**, Next 16's **Turbopack inlines the generated clients** — including `activeProvider:"sqlite"` — into `.next/server/chunks`.
- `docker-startup.sh` rewrites the schema to the runtime `DATABASE_PROVIDER` and re-runs `prisma generate`, but that only updates `node_modules/.prisma`. `next start` runs the **bundled** copy, so Postgres loaded the stale sqlite client and threw at client construction.

There are **two** generated clients: the main one (`@prisma/client`) and the separately-generated **log client** (`.prisma/log-client`, custom `output`, imported in `prisma/log-db.ts`). The log client is what actually crashed API routes — it's instantiated at module load by the request logger, so any route importing it threw before serving.

## Fix

Add `next.config.ts` marking **both** generated clients (by import specifier) plus the driver adapters as `serverExternalPackages`, so `next start` loads the runtime-regenerated clients from `node_modules`. One image continues to serve both providers.

## Verification (rebuilt image)

| Check | Postgres | SQLite |
|---|---|---|
| `PrismaClientInitializationError` | **0** | **0** |
| `/api/app-config`, `/api/settings` | 401 (was **500**) | 401 |
| `/api/family/public-list` | 200 | 200 |
| schema push + seed | ✓ | ✓ |
| inlined `activeProvider` in bundle | none | none |

- **1332 unit tests pass** (103 files), incl. 3 new regression guards in `tests/next-config-prisma-external.test.ts`.

## Notes

- Targets **`feat-short-links`** for integration after that dev work lands (per request).
- Functional verification was run on an image built from `main`; the fix is a bundler-config file and is base-independent, but happy to rebuild on this base if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)