### PR TITLE
fix(timeline): improve mobile navigation and export filenames

### DIFF
--- a/app/(app)/[slug]/client-layout.tsx
+++ b/app/(app)/[slug]/client-layout.tsx
@@ -852,7 +852,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
           )}
           
           {/* Main content area */}
-          <div className={`flex flex-col flex-1 h-dvh ${isWideScreen ? 'w-[calc(100%-16rem)]' : 'w-full'}`}>
+          <div className={`flex min-w-0 flex-col flex-1 h-dvh ${isWideScreen ? 'w-[calc(100%-16rem)]' : 'w-full'}`}>
             <header className="w-full bg-gradient-to-r from-teal-600 to-teal-700 sticky top-0 z-40 pt-[env(safe-area-inset-top)]">
               <div className="mx-auto py-2">
                 <div className="flex justify-between items-center h-16"> {/* Fixed height for consistency */}
@@ -923,7 +923,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
             {/* Account Expiration Banner - shows for both account users and caretakers */}
             <AccountExpirationBanner isAccountAuth={isAccountAuth} />
             
-            <main id="main-content" className="flex-1 min-h-0 overflow-y-auto relative z-0">
+            <main id="main-content" className="flex-1 min-h-0 min-w-0 overflow-y-auto relative z-0">
               {children}
             </main>
           </div>

--- a/app/api/timeline/export/route.ts
+++ b/app/api/timeline/export/route.ts
@@ -325,6 +325,20 @@ function getActivityTime(activity: any): number {
   return 0;
 }
 
+function attachmentDisposition(filename: string): string {
+  const asciiFallback = filename
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\x20-\x7E]/g, '_')
+    .replace(/[<>:"/\\|?*]/g, '_');
+  const encodedFilename = encodeURIComponent(filename).replace(
+    /['()*]/g,
+    character => `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+
+  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
+}
+
 async function handleGet(req: NextRequest, authContext: AuthResult) {
   try {
     const { familyId: userFamilyId } = authContext;
@@ -565,7 +579,7 @@ async function handleGet(req: NextRequest, authContext: AuthResult) {
       return new NextResponse(buffer, {
         headers: {
           'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-          'Content-Disposition': `attachment; filename="${filename}"`,
+          'Content-Disposition': attachmentDisposition(filename),
           'Content-Length': buffer.byteLength.toString(),
         },
       });
@@ -578,7 +592,7 @@ async function handleGet(req: NextRequest, authContext: AuthResult) {
     return new NextResponse(csvContent, {
       headers: {
         'Content-Type': 'text/csv;charset=utf-8;',
-        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Disposition': attachmentDisposition(filename),
       },
     });
   } catch (error) {

--- a/src/components/ActivityTileGroup/index.tsx
+++ b/src/components/ActivityTileGroup/index.tsx
@@ -450,7 +450,7 @@ export function ActivityTileGroup({
     case 'sleep': {
       const isLeftmost = activity === firstVisibleActivity;
       return (
-        <div key="sleep" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+        <div key="sleep" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
           <ActivityTile
             activity={{
               type: 'NAP', // Using a valid SleepType enum value
@@ -508,7 +508,7 @@ export function ActivityTileGroup({
         const isBabyFeeding = selectedBaby?.id && feedingBabies?.has(selectedBaby.id);
         const isLeftmost = activity === firstVisibleActivity;
         return (
-          <div key="feed" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="feed" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 type: 'BOTTLE',
@@ -566,7 +566,7 @@ export function ActivityTileGroup({
       case 'diaper': {
         const isLeftmost = activity === firstVisibleActivity;
         return (
-          <div key="diaper" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="diaper" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 type: 'WET',
@@ -604,7 +604,7 @@ export function ActivityTileGroup({
       }
       case 'note':
         return (
-          <div key="note" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="note" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'note-button',
@@ -629,7 +629,7 @@ export function ActivityTileGroup({
         );
       case 'photo':
         return (
-          <div key="photo" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="photo" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'photo-button',
@@ -661,7 +661,7 @@ export function ActivityTileGroup({
         );
       case 'bath':
         return (
-          <div key="bath" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="bath" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'bath-button',
@@ -689,7 +689,7 @@ export function ActivityTileGroup({
         );
       case 'pump':
         return (
-          <div key="pump" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="pump" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'pump-button',
@@ -719,7 +719,7 @@ export function ActivityTileGroup({
         );
       case 'measurement':
         return (
-          <div key="measurement" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="measurement" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'measurement-button',
@@ -746,7 +746,7 @@ export function ActivityTileGroup({
         );
       case 'milestone':
         return (
-          <div key="milestone" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="milestone" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'milestone-button',
@@ -772,7 +772,7 @@ export function ActivityTileGroup({
         );
       case 'play':
         return (
-          <div key="play" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="play" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'play-button',
@@ -801,7 +801,7 @@ export function ActivityTileGroup({
         );
       case 'medicine':
         return (
-          <div key="medicine" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="medicine" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'medicine-button',
@@ -836,7 +836,7 @@ export function ActivityTileGroup({
         );
       case 'vaccine':
         return (
-          <div key="vaccine" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="vaccine" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'vaccine-button',
@@ -863,7 +863,7 @@ export function ActivityTileGroup({
         );
       case 'food':
         return (
-          <div key="food" className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+          <div key="food" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
               activity={{
                 id: 'food-button',
@@ -896,14 +896,14 @@ export function ActivityTileGroup({
 
   return (
     <div className="activity-tile-group">
-      <div ref={scrollContainerRef} className="flex overflow-x-auto border-0 no-scrollbar snap-x snap-mandatory relative p-2 gap-1">
+      <div ref={scrollContainerRef} className="flex overflow-x-auto overscroll-x-contain border-0 no-scrollbar relative p-2 gap-1">
         {/* Render activity tiles based on order and visibility */}
         {activityOrder
           .filter(activity => activity !== 'photo' || photosEnabled)
           .map(activity => renderActivityTile(activity))}
 
         {/* Configure Button for customizing activity tiles */}
-        <div className="relative w-[82px] min-h-24 flex-shrink-0 snap-center">
+        <div className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button className="w-full h-full bg-transparent border-0 cursor-pointer p-0 m-0">

--- a/src/components/ActivityTileGroup/index.tsx
+++ b/src/components/ActivityTileGroup/index.tsx
@@ -472,15 +472,12 @@ export function ActivityTileGroup({
     food: t('Food')
   };
 
-  const firstVisibleActivity = activityOrder.find(a => visibleActivities.has(a));
-
   // Function to render activity tile based on type
   const renderActivityTile = (activity: ActivityType) => {
     if (!visibleActivities.has(activity)) return null;
 
     switch (activity) {
     case 'sleep': {
-      const isLeftmost = activity === firstVisibleActivity;
       return (
         <div key="sleep" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
           <ActivityTile
@@ -511,8 +508,6 @@ export function ActivityTileGroup({
               !exceeds24Hours(sleepStartTime[selectedBaby.id]) && (
                 <StatusBubble
                   status="sleeping"
-                  className={`overflow-visible ${isLeftmost ? 'z-[39]' : 'z-40'}`}
-                  screenEdgeAware={isLeftmost}
                   durationInMinutes={0}
                   startTime={sleepStartTime[selectedBaby.id]?.toISOString()}
                 />
@@ -521,8 +516,6 @@ export function ActivityTileGroup({
               !sleepStartTime[selectedBaby.id] && lastSleepEndTime[selectedBaby.id] && !exceeds24Hours(lastSleepEndTime[selectedBaby.id]) && (
                 <StatusBubble
                   status="awake"
-                  className={`overflow-visible ${isLeftmost ? 'z-[39]' : 'z-40'}`}
-                  screenEdgeAware={isLeftmost}
                   durationInMinutes={calculateDurationMinutes(
                     lastSleepEndTime[selectedBaby.id].toISOString(),
                     new Date().toISOString()
@@ -538,7 +531,6 @@ export function ActivityTileGroup({
       }
       case 'feed': {
         const isBabyFeeding = selectedBaby?.id && feedingBabies?.has(selectedBaby.id);
-        const isLeftmost = activity === firstVisibleActivity;
         return (
           <div key="feed" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
@@ -567,8 +559,6 @@ export function ActivityTileGroup({
             {isBabyFeeding ? (
               <StatusBubble
                 status="feedActive"
-                className={`overflow-visible ${isLeftmost ? 'z-[39]' : 'z-40'}`}
-                screenEdgeAware={isLeftmost}
                 durationInMinutes={0}
               />
             ) : (
@@ -582,8 +572,6 @@ export function ActivityTileGroup({
                 return selectedBaby?.id && effectiveFeedTime && !exceeds24Hours(effectiveFeedTime) && (
                   <StatusBubble
                     status="feed"
-                    className={`overflow-visible ${isLeftmost ? 'z-[39]' : 'z-40'}`}
-                    screenEdgeAware={isLeftmost}
                     durationInMinutes={0}
                     startTime={effectiveFeedTime.toISOString()}
                     warningTime={selectedBaby.feedWarningTime as string}
@@ -596,7 +584,6 @@ export function ActivityTileGroup({
         );
       }
       case 'diaper': {
-        const isLeftmost = activity === firstVisibleActivity;
         return (
           <div key="diaper" className="relative w-[82px] min-h-24 flex-shrink-0 snap-start">
             <ActivityTile
@@ -623,8 +610,6 @@ export function ActivityTileGroup({
             {selectedBaby?.id && lastDiaperTime[selectedBaby.id] && !exceeds24Hours(lastDiaperTime[selectedBaby.id]) && (
               <StatusBubble
                 status="diaper"
-                className={`overflow-visible ${isLeftmost ? 'z-[39]' : 'z-40'}`}
-                screenEdgeAware={isLeftmost}
                 durationInMinutes={0}
                 startTime={lastDiaperTime[selectedBaby.id].toISOString()}
                 warningTime={selectedBaby.diaperWarningTime as string}

--- a/src/components/ActivityTileGroup/index.tsx
+++ b/src/components/ActivityTileGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { ActivityTile } from '@/src/components/ui/activity-tile';
 import { StatusBubble } from "@/src/components/ui/status-bubble";
 import { SleepLogResponse, FeedLogResponse, DiaperLogResponse, NoteResponse, BathLogResponse, PumpLogResponse, PlayLogResponse, MeasurementResponse, MilestoneResponse, MedicineLogResponse, VaccineLogResponse, FoodLogResponse, ActivitySettings } from '@/app/api/types';
@@ -127,20 +127,50 @@ export function ActivityTileGroup({
   const [draggedActivity, setDraggedActivity] = useState<ActivityType | null>(null);
   const touchTimeoutRef = React.useRef<NodeJS.Timeout | null>(null); // Ref for touch start timeout
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const scrolledRef = useRef(false);
 
-  // Convert vertical mouse wheel events to horizontal scroll
+  // Convert vertical wheel to horizontal scroll. Do not listen to
+  // `scroll`: CSS snap fires it on load, and that is the jump we undo.
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
+    let touchStartX = 0;
     const handleWheel = (e: WheelEvent) => {
+      if (e.deltaX !== 0 || e.deltaY !== 0) scrolledRef.current = true;
       if (e.deltaY !== 0) {
         e.preventDefault();
         container.scrollLeft += e.deltaY;
       }
     };
+    const handleTouchStart = (e: TouchEvent) => {
+      touchStartX = e.touches[0].clientX;
+    };
+    const handleTouchMove = (e: TouchEvent) => {
+      if (Math.abs(e.touches[0].clientX - touchStartX) > 8) {
+        scrolledRef.current = true;
+      }
+    };
     container.addEventListener('wheel', handleWheel, { passive: false });
-    return () => container.removeEventListener('wheel', handleWheel);
+    container.addEventListener('touchstart', handleTouchStart, { passive: true });
+    container.addEventListener('touchmove', handleTouchMove, { passive: true });
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+      container.removeEventListener('touchstart', handleTouchStart);
+      container.removeEventListener('touchmove', handleTouchMove);
+    };
   }, []);
+
+  // Settings load reorders tiles; snap then jumps the row. Pin to 0
+  // until the user moves it. The extra frame catches snap after layout.
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || scrolledRef.current) return;
+    container.scrollLeft = 0;
+    const frame = requestAnimationFrame(() => {
+      if (!scrolledRef.current) container.scrollLeft = 0;
+    });
+    return () => cancelAnimationFrame(frame);
+  });
 
   // Refs for the move up/down menu items, keyed by `${activity}:up` / `${activity}:down`,
   // so focus can be restored after a reorder re-renders (moves) the dropdown rows
@@ -182,6 +212,7 @@ export function ActivityTileGroup({
         console.log(`Caretaker ID changed in localStorage: ${caretakerId} -> ${e.newValue}`);
         setCaretakerId(e.newValue);
         setSettingsLoaded(false);
+        scrolledRef.current = false;
         setSettingsModified(false); // Reset modified flag when caretaker changes
       }
     };
@@ -193,6 +224,7 @@ export function ActivityTileGroup({
         console.log(`Caretaker ID changed via event: ${caretakerId} -> ${newCaretakerId}`);
         setCaretakerId(newCaretakerId);
         setSettingsLoaded(false);
+        scrolledRef.current = false;
         setSettingsModified(false); // Reset modified flag when caretaker changes
       }
     };
@@ -896,7 +928,7 @@ export function ActivityTileGroup({
 
   return (
     <div className="activity-tile-group">
-      <div ref={scrollContainerRef} className="flex overflow-x-auto overscroll-x-contain border-0 no-scrollbar snap-x snap-mandatory relative p-2 gap-1">
+      <div ref={scrollContainerRef} className="flex overflow-x-auto overscroll-x-contain border-0 no-scrollbar snap-x snap-proximity relative p-2 gap-1">
         {/* Render activity tiles based on order and visibility */}
         {activityOrder
           .filter(activity => activity !== 'photo' || photosEnabled)

--- a/src/components/ActivityTileGroup/index.tsx
+++ b/src/components/ActivityTileGroup/index.tsx
@@ -896,7 +896,7 @@ export function ActivityTileGroup({
 
   return (
     <div className="activity-tile-group">
-      <div ref={scrollContainerRef} className="flex overflow-x-auto overscroll-x-contain border-0 no-scrollbar relative p-2 gap-1">
+      <div ref={scrollContainerRef} className="flex overflow-x-auto overscroll-x-contain border-0 no-scrollbar snap-x snap-mandatory relative p-2 gap-1">
         {/* Render activity tiles based on order and visibility */}
         {activityOrder
           .filter(activity => activity !== 'photo' || photosEnabled)

--- a/src/components/Timeline/TimelineV2/TimelineV2DailyStats.css
+++ b/src/components/Timeline/TimelineV2/TimelineV2DailyStats.css
@@ -119,6 +119,10 @@ html.dark .timeline-v2-daily-stats .text-amber-700 {
 
 
 /* Dark mode styles for TimelineV2Heatmap */
+.timeline-v2-heatmap-container {
+  -webkit-overflow-scrolling: touch;
+}
+
 html.dark .timeline-v2-heatmap-container {
   background-color: transparent !important;
 }

--- a/src/components/Timeline/TimelineV2/TimelineV2DailyStats.tsx
+++ b/src/components/Timeline/TimelineV2/TimelineV2DailyStats.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import {
   ChevronLeft,
   ChevronRight,
@@ -98,6 +99,11 @@ const TimelineV2DailyStats: React.FC<TimelineV2DailyStatsProps> = ({
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [photosEnabled, setPhotosEnabled] = useState(false);
+  const [overlayMounted, setOverlayMounted] = useState(false);
+
+  useEffect(() => {
+    setOverlayMounted(true);
+  }, []);
 
   useEffect(() => {
     fetchPhotosEnabled().then(setPhotosEnabled);
@@ -803,44 +809,44 @@ const TimelineV2DailyStats: React.FC<TimelineV2DailyStatsProps> = ({
         )}
       </div>
 
-      {/* Mobile heatmap slide-out panel (right side, similar to FormPage) */}
-      <div className="fixed inset-0 z-40 md:hidden pointer-events-none">
-        {/* Overlay */}
-        <div
-          className={`absolute inset-0 bg-black/40 transition-opacity duration-300 ${
-            isHeatmapVisible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-          }`}
-          onClick={onHeatmapToggle}
-        />
-
-        {/* Slide-out panel */}
-        <div
-          className={`
-            absolute inset-y-0 right-0 w-24 bg-white shadow-xl
-            transform transition-transform duration-300
-            timeline-v2-heatmap-panel
-            ${isHeatmapVisible ? 'translate-x-0 pointer-events-auto' : 'translate-x-full pointer-events-none'}
-          `}
-        >
-          <div className="flex justify-end px-3 pt-2 mb-2">
-            <button
-              type="button"
-              className="text-xs inline-flex items-center gap-1 text-teal-600 hover:text-teal-700 underline underline-offset-2"
-              onClick={onHeatmapToggle}
-            >
-              <EyeOff className="h-3 w-3" aria-hidden="true" />
-              <span>{t('Hide')}</span>
-            </button>
+      {/* Mobile heatmap slide-out panel — portaled so header/tiles cannot cover it */}
+      {overlayMounted && createPortal(
+        <div className="fixed inset-0 z-[90] md:hidden pointer-events-none">
+          <div
+            className={`absolute inset-0 bg-black/40 touch-none transition-opacity duration-300 ${
+              isHeatmapVisible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+            }`}
+            onClick={onHeatmapToggle}
+          />
+          <div
+            className={`
+              fixed inset-y-0 w-24 bg-white shadow-xl flex flex-col
+              transition-[right] duration-300
+              timeline-v2-heatmap-panel
+              ${isHeatmapVisible ? 'right-0 pointer-events-auto' : '-right-24 pointer-events-none'}
+            `}
+          >
+            <div className="flex justify-end px-3 pt-[calc(0.5rem+env(safe-area-inset-top))] mb-2 shrink-0">
+              <button
+                type="button"
+                className="text-xs inline-flex items-center gap-1 text-teal-600 hover:text-teal-700 underline underline-offset-2"
+                onClick={onHeatmapToggle}
+              >
+                <EyeOff className="h-3 w-3" aria-hidden="true" />
+                <span>{t('Hide')}</span>
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 px-1 py-2 pb-[env(safe-area-inset-bottom)]">
+              <TimelineV2Heatmap
+                activities={heatmapActivities}
+                selectedDate={date}
+                isVisible={isHeatmapVisible}
+              />
+            </div>
           </div>
-          <div className="h-full px-1 py-2">
-            <TimelineV2Heatmap
-              activities={heatmapActivities}
-              selectedDate={date}
-              isVisible={isHeatmapVisible}
-            />
-          </div>
-        </div>
-      </div>
+        </div>,
+        document.body
+      )}
     </section>
   );
 };

--- a/src/components/Timeline/TimelineV2/TimelineV2DailyStats.tsx
+++ b/src/components/Timeline/TimelineV2/TimelineV2DailyStats.tsx
@@ -99,10 +99,10 @@ const TimelineV2DailyStats: React.FC<TimelineV2DailyStatsProps> = ({
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [photosEnabled, setPhotosEnabled] = useState(false);
-  const [overlayMounted, setOverlayMounted] = useState(false);
+  const [portalReady, setPortalReady] = useState(false);
 
   useEffect(() => {
-    setOverlayMounted(true);
+    setPortalReady(true);
   }, []);
 
   useEffect(() => {
@@ -810,7 +810,7 @@ const TimelineV2DailyStats: React.FC<TimelineV2DailyStatsProps> = ({
       </div>
 
       {/* Mobile heatmap slide-out panel — portaled so header/tiles cannot cover it */}
-      {overlayMounted && createPortal(
+      {portalReady && createPortal(
         <div className="fixed inset-0 z-[90] md:hidden pointer-events-none">
           <div
             className={`absolute inset-0 bg-black/40 touch-none transition-opacity duration-300 ${

--- a/src/components/Timeline/TimelineV2/TimelineV2Heatmap.tsx
+++ b/src/components/Timeline/TimelineV2/TimelineV2Heatmap.tsx
@@ -1,14 +1,15 @@
-import React, { useMemo, useEffect, useRef, useState } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import { Moon, Icon, LampWallDown } from 'lucide-react';
 import { diaper, bottleBaby } from '@lucide/lab';
 import { ActivityType } from '../types';
+import { useTimezone } from '@/app/context/timezone';
 import {
-  TIME_SLOTS,
   SLOT_MINUTES,
   HeatmapType,
-  HEATMAP_TYPES_IN_ORDER,
   HEATMAP_COLORS,
   buildHeatmapDataForActivities,
+  formatHeatmapHourLabel,
+  getHeatmapScrollTop,
   getSlotOpacity,
   interpolateColor,
 } from './timeline-heatmap.utils';
@@ -34,19 +35,12 @@ const HEATMAP_ICONS: Record<string, { icon: any; isLabIcon?: boolean }> = {
   pumps: { icon: LampWallDown },
 };
 
-// Format hour for labels (reuses pattern from Reports)
-const formatHourLabel = (hour: number): string => {
-  if (hour === 0 || hour === 24) return '12a';
-  if (hour === 12) return '12p';
-  if (hour < 12) return `${hour}a`;
-  return `${hour - 12}p`;
-};
-
 const TimelineV2Heatmap: React.FC<TimelineV2HeatmapProps> = ({
   activities,
   selectedDate,
   isVisible = true,
 }) => {
+  const { timeFormat } = useTimezone();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
 
@@ -72,51 +66,65 @@ const TimelineV2Heatmap: React.FC<TimelineV2HeatmapProps> = ({
     const content = contentRef.current;
     if (!container || !content) return;
 
+    let cancelled = false;
+    let frameId = 0;
+    const stopOnUserScroll = () => {
+      cancelled = true;
+    };
+
     const runAnimation = () => {
+      if (cancelled) return;
       const now = new Date();
       const minutesSinceMidnight = now.getHours() * 60 + now.getMinutes();
-      const totalMinutes = 24 * 60;
 
       const containerHeight = container.clientHeight;
       const contentHeight = content.clientHeight;
 
       // If layout hasn't stabilized yet, retry on the next frame
       if (containerHeight === 0 || contentHeight === 0) {
-        requestAnimationFrame(runAnimation);
+        if (getComputedStyle(container).display === 'none') return;
+        frameId = requestAnimationFrame(runAnimation);
         return;
       }
 
-      const currentY = contentHeight - (minutesSinceMidnight / totalMinutes) * contentHeight;
-      const targetCenterY = containerHeight / 2;
-      const minOffset = containerHeight - contentHeight; // midnight at bottom (<= 0)
-      const maxOffset = 0; // content fully aligned at top
-      const initialOffset = minOffset;
-      // Center current time when possible, but don't scroll past top/bottom
-      const unclampedTargetOffset = targetCenterY - currentY;
-      const targetOffset = Math.max(minOffset, Math.min(maxOffset, unclampedTargetOffset));
+      const targetScrollTop = getHeatmapScrollTop({
+        containerHeight,
+        contentHeight,
+        minutesSinceMidnight,
+      });
+      const initialScrollTop = Math.max(0, contentHeight - containerHeight);
+
+      container.scrollTop = initialScrollTop;
 
       let start: number | null = null;
       const duration = 600; // ms
 
       const animate = (timestamp: number) => {
+        if (cancelled) return;
         if (start === null) start = timestamp;
         const elapsed = timestamp - start;
         const t = Math.min(1, elapsed / duration);
         const eased = t * t * (3 - 2 * t); // smoothstep
-        const currentOffset = initialOffset + (targetOffset - initialOffset) * eased;
-        content.style.transform = `translateY(${currentOffset}px)`;
+        container.scrollTop = initialScrollTop + (targetScrollTop - initialScrollTop) * eased;
 
         if (t < 1) {
-          requestAnimationFrame(animate);
+          frameId = requestAnimationFrame(animate);
         }
       };
 
-      // start with midnight at bottom
-      content.style.transform = `translateY(${initialOffset}px)`;
-      requestAnimationFrame(animate);
+      frameId = requestAnimationFrame(animate);
     };
 
-    runAnimation();
+    container.addEventListener('touchstart', stopOnUserScroll, { passive: true });
+    container.addEventListener('wheel', stopOnUserScroll, { passive: true });
+    frameId = requestAnimationFrame(runAnimation);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frameId);
+      container.removeEventListener('touchstart', stopOnUserScroll);
+      container.removeEventListener('wheel', stopOnUserScroll);
+    };
   }, [isVisible, activities]);
 
   if (!heatmapData) {
@@ -129,11 +137,11 @@ const TimelineV2Heatmap: React.FC<TimelineV2HeatmapProps> = ({
   return (
     <div
       ref={containerRef}
-      className="relative h-full w-full overflow-hidden timeline-v2-heatmap-container"
+      className="relative h-full w-full overflow-y-auto overflow-x-hidden overscroll-contain touch-pan-y timeline-v2-heatmap-container"
     >
       <div
         ref={contentRef}
-        className="absolute inset-x-0 timeline-v2-heatmap-content"
+        className="relative timeline-v2-heatmap-content"
         style={{ height: CHART_HEIGHT, width: totalWidth, marginLeft: 8 }}
       >
         {/* Hour grid lines */}
@@ -161,7 +169,7 @@ const TimelineV2Heatmap: React.FC<TimelineV2HeatmapProps> = ({
                       transform: 'translateY(-50%)',
                     }}
                   >
-                    {formatHourLabel(hour)}
+                    {formatHeatmapHourLabel(hour, timeFormat)}
                   </span>
                 )}
               </div>

--- a/src/components/Timeline/TimelineV2/timeline-heatmap.utils.ts
+++ b/src/components/Timeline/TimelineV2/timeline-heatmap.utils.ts
@@ -1,5 +1,6 @@
 import { ActivityType } from '../types';
 import { groupBreastFeedSessions } from '@/src/utils/feedSessionUtils';
+import type { TimeFormatSetting } from '@/src/utils/dateFormat';
 
 // Shared heatmap configuration
 export const TIME_SLOTS = 288; // 5-minute slots
@@ -75,6 +76,39 @@ export const getSlotOpacity = (intensity: number): number => {
 export const timeToSlot = (hours: number): number => {
   const slot = Math.floor((hours * 60) / SLOT_MINUTES);
   return Math.max(0, Math.min(TIME_SLOTS - 1, slot));
+};
+
+const MINUTES_IN_DAY = 24 * 60;
+
+/** Compact hour tick for the heatmap axis (12a / 00). */
+export const formatHeatmapHourLabel = (
+  hour: number,
+  timeFormat: TimeFormatSetting,
+): string => {
+  if (timeFormat === '24h') {
+    const h = hour === 24 ? 0 : hour;
+    return String(h).padStart(2, '0');
+  }
+  if (hour === 0 || hour === 24) return '12a';
+  if (hour === 12) return '12p';
+  if (hour < 12) return `${hour}a`;
+  return `${hour - 12}p`;
+};
+
+/** Scroll offset that centers the current time in a 24h heatmap (midnight at the bottom). */
+export const getHeatmapScrollTop = ({
+  containerHeight,
+  contentHeight,
+  minutesSinceMidnight,
+}: {
+  containerHeight: number;
+  contentHeight: number;
+  minutesSinceMidnight: number;
+}): number => {
+  if (containerHeight <= 0 || contentHeight <= 0) return 0;
+  const currentY = contentHeight - (minutesSinceMidnight / MINUTES_IN_DAY) * contentHeight;
+  const maxScroll = Math.max(0, contentHeight - containerHeight);
+  return Math.max(0, Math.min(maxScroll, currentY - containerHeight / 2));
 };
 
 const getHours = (d: Date) => d.getHours() + d.getMinutes() / 60;

--- a/src/components/ui/status-bubble/index.tsx
+++ b/src/components/ui/status-bubble/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Moon, Sun, Icon } from 'lucide-react';
 import { diaper, bottleBaby } from '@lucide/lab';
 import { cn } from "@/src/lib/utils";
@@ -23,33 +23,12 @@ export function StatusBubble({
   durationInMinutes,
   warningTime,
   className,
-  screenEdgeAware,
   startTime,
   activityType
 }: StatusBubbleProps & { startTime?: string }) {
   const { userTimezone, calculateDurationMinutes, formatDuration } = useTimezone();
   const { t } = useLocalization();
   const [calculatedDuration, setCalculatedDuration] = useState(durationInMinutes);
-  const bubbleRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    if (!screenEdgeAware || !bubbleRef.current) return;
-
-    const checkPosition = () => {
-      const el = bubbleRef.current;
-      if (!el) return;
-      el.style.transform = '';
-      const rect = el.getBoundingClientRect();
-      if (rect.left < 2) {
-        el.style.transform = `translateX(${Math.ceil(Math.abs(rect.left) + 2)}px)`;
-      }
-    };
-
-    checkPosition();
-
-    window.addEventListener('resize', checkPosition);
-    return () => window.removeEventListener('resize', checkPosition);
-  }, [screenEdgeAware, status]);
   
   const updateDuration = useCallback(() => {
     if (startTime) {
@@ -174,7 +153,6 @@ export function StatusBubble({
 
   return (
     <div
-      ref={screenEdgeAware ? bubbleRef : undefined}
       role="img"
       aria-label={ariaLabel}
       className={cn(
@@ -184,7 +162,7 @@ export function StatusBubble({
       )}
     >
       {icon}
-      <span>{status === 'feedActive' ? t('Feeding') : formatDuration(displayDuration)}</span>
+      <span className="min-w-0 truncate">{status === 'feedActive' ? t('Feeding') : formatDuration(displayDuration)}</span>
     </div>
   );
 }

--- a/src/components/ui/status-bubble/status-bubble.styles.ts
+++ b/src/components/ui/status-bubble/status-bubble.styles.ts
@@ -1,5 +1,5 @@
 export const statusBubbleStyles = {
-  base: "absolute top-[-5px] right-[-5px] px-3 py-1 rounded-2xl flex items-center gap-1.5 text-xs font-medium z-50 drop-shadow-md",
+  base: "absolute top-[-5px] right-0 max-w-full min-w-0 px-2 py-1 rounded-2xl flex items-center gap-1 text-xs font-medium z-50 drop-shadow-md overflow-hidden",
   icon: "h-3.5 w-3.5",
   statusStyles: {
     sleeping: {

--- a/src/components/ui/status-bubble/status-bubble.types.ts
+++ b/src/components/ui/status-bubble/status-bubble.types.ts
@@ -12,8 +12,6 @@ export interface StatusBubbleProps {
   warningTime?: string;
   /** Additional CSS classes */
   className?: string;
-  /** Dynamically reposition bubble if it would clip the left screen edge */
-  screenEdgeAware?: boolean;
   /** Type of activity this status bubble is for (used to filter relevant activities) */
   activityType?: 'sleep' | 'feed' | 'diaper' | 'pump';
 }

--- a/tests/heatmap-hour-label.test.ts
+++ b/tests/heatmap-hour-label.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { formatHeatmapHourLabel } from '@/src/components/Timeline/TimelineV2/timeline-heatmap.utils';
+
+describe('formatHeatmapHourLabel', () => {
+  it('keeps compact 12-hour labels', () => {
+    expect(formatHeatmapHourLabel(0, '12h')).toBe('12a');
+    expect(formatHeatmapHourLabel(24, '12h')).toBe('12a');
+    expect(formatHeatmapHourLabel(3, '12h')).toBe('3a');
+    expect(formatHeatmapHourLabel(12, '12h')).toBe('12p');
+    expect(formatHeatmapHourLabel(15, '12h')).toBe('3p');
+  });
+
+  it('uses zero-padded 24-hour labels', () => {
+    expect(formatHeatmapHourLabel(0, '24h')).toBe('00');
+    expect(formatHeatmapHourLabel(24, '24h')).toBe('00');
+    expect(formatHeatmapHourLabel(3, '24h')).toBe('03');
+    expect(formatHeatmapHourLabel(12, '24h')).toBe('12');
+    expect(formatHeatmapHourLabel(15, '24h')).toBe('15');
+    expect(formatHeatmapHourLabel(21, '24h')).toBe('21');
+  });
+});

--- a/tests/timeline-heatmap-scroll.test.ts
+++ b/tests/timeline-heatmap-scroll.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getHeatmapScrollTop } from '@/src/components/Timeline/TimelineV2/timeline-heatmap.utils';
+
+describe('getHeatmapScrollTop', () => {
+  const layout = { containerHeight: 600, contentHeight: 1500 };
+
+  it('centers noon in the viewport', () => {
+    // 1500px chart, midnight at the bottom → noon at 750px from the top.
+    // A 600px viewport centers 750 at 300, so scrollTop is 450.
+    expect(getHeatmapScrollTop({ ...layout, minutesSinceMidnight: 12 * 60 })).toBe(450);
+  });
+
+  it('clamps midnight to the bottom of the chart', () => {
+    // Max scroll on a 1500px chart in a 600px viewport is 900.
+    expect(getHeatmapScrollTop({ ...layout, minutesSinceMidnight: 0 })).toBe(900);
+  });
+
+  it('clamps end of day to the top of the chart', () => {
+    expect(getHeatmapScrollTop({ ...layout, minutesSinceMidnight: 23 * 60 + 59 })).toBe(0);
+  });
+
+  it('returns 0 when layout sizes are not ready', () => {
+    expect(getHeatmapScrollTop({ containerHeight: 0, contentHeight: 1500, minutesSinceMidnight: 720 })).toBe(0);
+    expect(getHeatmapScrollTop({ containerHeight: 600, contentHeight: 0, minutesSinceMidnight: 720 })).toBe(0);
+  });
+});

--- a/tests/timelineExportRoute.test.ts
+++ b/tests/timelineExportRoute.test.ts
@@ -93,10 +93,16 @@ describe('timeline export route', () => {
     ['xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
   ] as const)('downloads %s when the baby name contains Polish characters', async (format, contentType) => {
     const response = await GET(exportRequest(format) as any);
+    const disposition = response.headers.get('content-disposition');
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain(contentType);
-    expect(response.headers.get('content-disposition')).toMatch(/^attachment;/);
+    expect(disposition).toMatch(
+      new RegExp(
+        `^attachment; filename="activity-log-_ucja-Zo_c-\\d{4}-\\d{2}-\\d{2}\\.${format}"; ` +
+          `filename\\*=UTF-8''activity-log-%C5%81ucja-%C5%BB%C3%B3%C5%82%C4%87-\\d{4}-\\d{2}-\\d{2}\\.${format}$`
+      )
+    );
     expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
   });
 });

--- a/tests/timelineExportRoute.test.ts
+++ b/tests/timelineExportRoute.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const findMany = () => ({ findMany: vi.fn() });
+
+  return {
+    prisma: {
+      baby: { findFirst: vi.fn() },
+      sleepLog: findMany(),
+      feedLog: findMany(),
+      diaperLog: findMany(),
+      note: findMany(),
+      bathLog: findMany(),
+      pumpLog: findMany(),
+      playLog: findMany(),
+      milestone: findMany(),
+      measurement: findMany(),
+      medicineLog: findMany(),
+      breastMilkAdjustment: findMany(),
+      vaccineLog: findMany(),
+      foodLog: findMany(),
+    },
+  };
+});
+
+vi.mock('../app/api/db', () => ({
+  default: mocks.prisma,
+}));
+
+vi.mock('../app/api/utils/auth', () => ({
+  withAuthContext:
+    (handler: (request: Request, auth: Record<string, unknown>) => Promise<Response>) =>
+    (request: Request) =>
+      handler(request, { authenticated: true, familyId: 'family-1' }),
+}));
+
+import { GET } from '../app/api/timeline/export/route';
+
+function exportRequest(format: 'csv' | 'xlsx') {
+  return new Request(
+    'http://localhost/api/timeline/export?babyId=baby-1' +
+      '&startDate=2026-08-23T22%3A00%3A00.000Z' +
+      '&endDate=2026-08-31T21%3A59%3A59.999Z' +
+      `&format=${format}&timezone=Europe%2FWarsaw&language=pl`
+  );
+}
+
+const findManyDelegates = [
+  mocks.prisma.sleepLog,
+  mocks.prisma.feedLog,
+  mocks.prisma.diaperLog,
+  mocks.prisma.note,
+  mocks.prisma.bathLog,
+  mocks.prisma.pumpLog,
+  mocks.prisma.playLog,
+  mocks.prisma.milestone,
+  mocks.prisma.measurement,
+  mocks.prisma.medicineLog,
+  mocks.prisma.breastMilkAdjustment,
+  mocks.prisma.vaccineLog,
+  mocks.prisma.foodLog,
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.prisma.baby.findFirst.mockResolvedValue({
+    id: 'baby-1',
+    familyId: 'family-1',
+    firstName: 'Łucja',
+    lastName: 'Żółć',
+  });
+  for (const delegate of findManyDelegates) {
+    delegate.findMany.mockResolvedValue([]);
+  }
+  mocks.prisma.feedLog.findMany.mockResolvedValue([
+    {
+      id: 'feed-1',
+      babyId: 'baby-1',
+      familyId: 'family-1',
+      time: new Date('2026-08-31T10:00:00.000Z'),
+      type: 'BOTTLE',
+      amount: 120,
+      unitAbbr: 'ML',
+      bottleType: 'Formula',
+      caretaker: { name: 'Mama' },
+    },
+  ]);
+});
+
+describe('timeline export route', () => {
+  it.each([
+    ['csv', 'text/csv'],
+    ['xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+  ] as const)('downloads %s when the baby name contains Polish characters', async (format, contentType) => {
+    const response = await GET(exportRequest(format) as any);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain(contentType);
+    expect(response.headers.get('content-disposition')).toMatch(/^attachment;/);
+    expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep the activity tile row at scrollLeft 0 on load. Loading settings reordered tiles, and snap-mandatory jumped the row to a middle tile.
- Keep each status bubble on its own tile. screenEdgeAware translated the first bubble when that tile was off-screen, so the feed timer landed on Sleep.
- Use snap-start and snap-proximity on the tile row so swipe still snaps, without a forced jump after layout.
- Render the mobile heatmap above app chrome, keep it scrollable, and honor 12h/24h labels.
- Let nested timeline content shrink inside the flex layout (`min-w-0`) instead of widening the page past the viewport.
- Encode timeline export filenames as ASCII plus RFC 5987 when the baby name is non-ASCII.

## Test plan

- [ ] Log entry on a phone: tile row starts at Sleep/Feed (or the first configured tile), not the middle
- [ ] Scroll the tile row, then confirm the feed bubble stays on Feed and does not appear on Sleep
- [ ] Timeline heatmap sits above the bottom chrome, scrolls, and matches 12h/24h
- [ ] Timeline does not force the page wider than the screen
- [ ] Export CSV/XLSX with a non-ASCII baby name; download filename is valid